### PR TITLE
add GH actions workflow to release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ on:
 
 permissions:
   contents: write
-  # packages: write
+  packages: write
   # issues: write
 
 jobs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,53 @@
+name: goreleaser
+
+on:
+  push:
+    # run only against tags
+    tags:
+      - '*'
+
+permissions:
+  contents: write
+  # packages: write
+  # issues: write
+
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+    env:
+      DOCKER_BUILDKIT: 1
+
+    steps:
+      # - uses: zendesk/setup-jsonnet@v10
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      # Required so that we fetch tags as well (https://github.com/actions/checkout/issues/448)
+      - run: |
+          git fetch origin +refs/tags/*:refs/tags/*
+          git tag -l -n1
+      - name: Docker Login (GCR)
+        env:
+          GCP_CONTAINERS_SA_JSON: ${{ secrets.GCP_CONTAINERS_SA_JSON }}
+        run: |
+          printf %s "$GCP_CONTAINERS_SA_JSON" | docker login -u _json_key --password-stdin https://us.gcr.io
+      - name: Configure GCS Auth
+        env:
+          GCS_AUTH: ${{ secrets.GCS_AUTH }}
+        run: |
+          set -e
+          printf %s "$GCS_AUTH" > gs-creds.json
+          jq -r .client_email gs-creds.json > iam-account.txt
+
+          gcloud auth activate-service-account --key-file ./gs-creds.json
+      - uses: actions/setup-go@v3
+        with:
+          go-version: '>=1.19.5'
+          cache: true
+      - uses: goreleaser/goreleaser-action@v4
+        with:
+          distribution: goreleaser
+          version: latest
+          args: release --rm-dist
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,50 +4,47 @@ on:
   push:
     # run only against tags
     tags:
-      - '*'
-
+      - "v*"
 permissions:
   contents: write
   packages: write
-  # issues: write
 
 jobs:
   goreleaser:
     runs-on: ubuntu-latest
-    env:
-      DOCKER_BUILDKIT: 1
-
     steps:
-      # - uses: zendesk/setup-jsonnet@v10
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      # Required so that we fetch tags as well (https://github.com/actions/checkout/issues/448)
-      - run: |
-          git fetch origin +refs/tags/*:refs/tags/*
-          git tag -l -n1
-      - name: Docker Login (GCR)
-        env:
-          GCP_CONTAINERS_SA_JSON: ${{ secrets.GCP_CONTAINERS_SA_JSON }}
-        run: |
-          printf %s "$GCP_CONTAINERS_SA_JSON" | docker login -u _json_key --password-stdin https://us.gcr.io
-      - name: Configure GCS Auth
-        env:
-          GCS_AUTH: ${{ secrets.GCS_AUTH }}
-        run: |
-          set -e
-          printf %s "$GCS_AUTH" > gs-creds.json
-          jq -r .client_email gs-creds.json > iam-account.txt
-
-          gcloud auth activate-service-account --key-file ./gs-creds.json
+      - name: Set GIT_LAST_COMMIT_DATE
+        run: echo "GIT_LAST_COMMIT_DATE=$(git log -1 --date=iso-strict --format=%cd)" >> $GITHUB_ENV
+      # Forces goreleaser to use the correct previous tag for the changelog
+      - name: Set GORELEASER_PREVIOUS_TAG
+        run: echo "GORELEASER_PREVIOUS_TAG=$(git tag -l --sort=-version:refname | grep -E '^v.*' | head -n 2 | tail -1)" >> $GITHUB_ENV
+      - run: git fetch --force --tags
       - uses: actions/setup-go@v3
         with:
-          go-version: '>=1.19.5'
+          go-version: ">=1.19.5"
           cache: true
+      # setup docker buildx
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      # login to docker hub
+      - uses: docker/login-action@v2
+        name: Login to Docker Hub
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
       - uses: goreleaser/goreleaser-action@v4
         with:
+          # either 'goreleaser' (default) or 'goreleaser-pro':
           distribution: goreleaser
           version: latest
           args: release --rm-dist
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GH_BOT_ACCESS_TOKEN }}
+          # Your GoReleaser Pro key, if you are using the 'goreleaser-pro'
+          # distribution:
+          # GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,12 +39,8 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - uses: goreleaser/goreleaser-action@v4
         with:
-          # either 'goreleaser' (default) or 'goreleaser-pro':
           distribution: goreleaser
           version: latest
           args: release --rm-dist
         env:
           GITHUB_TOKEN: ${{ secrets.GH_BOT_ACCESS_TOKEN }}
-          # Your GoReleaser Pro key, if you are using the 'goreleaser-pro'
-          # distribution:
-          # GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -36,7 +36,7 @@ dockers:
       - pdc
     dockerfile: ./cmd/pdc/Dockerfile
     image_templates:
-    - grafana/pdc-agent
+    - us.gcr.io/grafana/pdc-agent:latest
 
 checksum:
   name_template: 'checksums.txt'

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,4 +1,5 @@
 # Make sure to check the documentation at https://goreleaser.com
+project_name: pdc-agent
 before:
   hooks:
     - go mod tidy
@@ -36,7 +37,9 @@ dockers:
       - pdc
     dockerfile: ./cmd/pdc/Dockerfile
     image_templates:
-    - us.gcr.io/grafana/pdc-agent:latest
+    - grafana/{{ .ProjectName }}:latest
+    - grafana/{{ .ProjectName }}:{{ .Version }}
+
 
 checksum:
   name_template: 'checksums.txt'


### PR DESCRIPTION
This workflow is heavily based on the [grafana/phlare release workflow](https://github.com/grafana/phlare/blob/main/.github/workflows/release.yml). it pushes releases to docker hub

prerequisites:
- [x] get docker hub credentials into GH actions secrets - used `grafanabot` credentials to log into dockerhub (found in 1Password)