### PR TITLE
add GITHUB_TOKEN to goreleaser env

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,3 +42,5 @@ jobs:
           distribution: goreleaser
           version: latest
           args: release --rm-dist --debug
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
https://github.com/grafana/pdc-agent/pull/7 removed the custom token, but also removed the env from being declared for goreleaser. This PR adds the `GITHUB_TOKEN` env definition back to goreleaser, using the default `GITHUB_TOKEN` secret provided by GH actions.