### PR TITLE
add ServerAliveInterval to ensure the clients reconnects

### DIFF
--- a/production/kubernetes/agent-bare.yaml
+++ b/production/kubernetes/agent-bare.yaml
@@ -34,6 +34,8 @@ spec:
         - UserKnownHostsFile=/var/run/secrets/grafana-pdc-agent/known_hosts
         - -o
         - CertificateFile=/var/run/secrets/grafana-pdc-agent/cert.pub
+        - -o
+        - ServerAliveInterval=15
         - -R
         - "0"
         - -vvv


### PR DESCRIPTION
Ensure clients automatically reconnects when the server disconnects first.

[ServerAliveInterval](https://man.openbsd.org/ssh_config.5#ServerAliveInterval) is added to prevent SSH disconnects or SSH connection hang.