### PR TITLE
Use openssh 9.3

### DIFF
--- a/cmd/pdc/Dockerfile
+++ b/cmd/pdc/Dockerfile
@@ -1,5 +1,5 @@
 FROM alpine:3.17
-RUN apk add --no-cache openssh
+RUN apk add --no-cache --repository=http://dl-cdn.alpinelinux.org/alpine/edge/main openssh
 COPY pdc /usr/bin/pdc
 RUN addgroup -g 30000 pdc && adduser -G pdc -u 30000 pdc -D
 USER 30000:30000


### PR DESCRIPTION
Openssh 9.3 is needed to allow `PermitRemoteOpen` to work correctly, [bug here](https://bugzilla.mindrot.org/show_bug.cgi?id=3515).

This version of openssh is only available on [alpine edge](https://pkgs.alpinelinux.org/packages?name=openssh&branch=edge&repo=&arch=&maintainer=), which will be released in a month. In the meantime, we should upgrade

