### PR TITLE
fix: ensure the binary is owned by the correct user

### DIFF
--- a/cmd/pdc/Dockerfile
+++ b/cmd/pdc/Dockerfile
@@ -2,5 +2,6 @@ FROM alpine:3.17
 RUN apk add --no-cache --repository=http://dl-cdn.alpinelinux.org/alpine/edge/main openssh
 COPY pdc /usr/bin/pdc
 RUN addgroup -g 30000 pdc && adduser -G pdc -u 30000 pdc -D
+RUN chown -R pdc:pdc /usr/bin/pdc
 USER 30000:30000
 ENTRYPOINT ["/usr/bin/pdc"]


### PR DESCRIPTION
Ensure the binary is owned by the correct user.

Currently seeing:
```
/bin/sh: ./pdc: not found
```