### PR TITLE
fix goreleaser version to 1.17.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,7 @@ jobs:
       - uses: goreleaser/goreleaser-action@v4
         with:
           distribution: goreleaser
-          version: latest
+          version: '1.17.0'
           args: release --rm-dist --debug
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
1.17.0 was the version used in the last successful CI: [link to job](https://github.com/grafana/pdc-agent/actions/runs/4668558667/jobs/8265803386)