### PR TITLE
add wrap_in_directory property to goreleaser config

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -38,7 +38,7 @@ linters:
     ## - contextcheck
     ## - cyclop
     ## - decorder
-    - depguard
+    # - depguard
     # - dogsled
     - dupl
     - dupword

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -26,13 +26,6 @@ linters-settings:
     replace-allow-list:
       # see https://github.com/dolthub/go-mysql-server/issues/1591
       - github.com/dolthub/go-mysql-server
-  depguard:
-    packages:
-      - github.com/pkg/errors
-      - gopkg.in/square/go-jose.v2
-    packages-with-error-message:
-      - github.com/pkg/errors: 'use `fmt.Errorf` instead, or the stdlib `errors` package'
-      - gopkg.in/square/go-jose.v2: 'use `github.com/go-jose/go-jose/v3` instead'
 
 linters:
   disable-all: true

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -28,6 +28,7 @@ archives:
     format_overrides:
     - goos: windows
       format: zip
+    wrap_in_directory: true
 
 dockers:
   - use: buildx


### PR DESCRIPTION
This will ensure that our archives unzip to a directory, and not just extract all files to the top level.