### PR TITLE
Bugfix: -ssh-flag option parses incorrectly when value contains whitespace

### DIFF
--- a/pkg/ssh/ssh.go
+++ b/pkg/ssh/ssh.go
@@ -102,8 +102,8 @@ func (s *Client) starting(ctx context.Context) error {
 				level.Error(s.logger).Log("msg", fmt.Sprintf("could not parse flags: %s", err))
 				return
 			}
-
 			level.Debug(s.logger).Log("msg", fmt.Sprintf("parsed flags: %s", flags))
+
 			cmd := exec.CommandContext(ctx, s.SSHCmd, flags...)
 			cmd.Stdout = os.Stdout
 			cmd.Stderr = os.Stderr
@@ -155,9 +155,9 @@ func (s *Client) SSHFlagsFromConfig() ([]string, error) {
 	}
 
 	for _, f := range s.cfg.SSHFlags {
-		// flags are in the format '-vv' or '-o Option=Value'. Split to flatten strings
-		// in the second format
-		result = append(result, strings.Split(f, " ")...)
+		// flags are in the format '-vv' or '-o Option=Value'. Split once to flatten strings
+		// in the second format whilst accommodating -o Option='value with whitespace'
+		result = append(result, strings.SplitN(f, " ", 1)...)
 	}
 
 	return result, nil

--- a/pkg/ssh/ssh_test.go
+++ b/pkg/ssh/ssh_test.go
@@ -125,13 +125,14 @@ func TestClient_SSHArgs(t *testing.T) {
 		cfg.SSHFlags = []string{
 			"-vvv",
 			"-o testoption=2",
+			"-o PermitRemoteOpen='host:123 host:456'",
 		}
 
 		sshClient := newTestClient(t, cfg)
 		result, err := sshClient.SSHFlagsFromConfig()
 
 		assert.Nil(t, err)
-		assert.Equal(t, strings.Split(fmt.Sprintf("-i %s 123@host.grafana.net -p 22 -R 0 -vv -o UserKnownHostsFile=%s -o CertificateFile=%s -o ServerAliveInterval=15 -vvv -o testoption=2", cfg.KeyFile, path.Join(cfg.KeyFileDir(), ssh.KnownHostsFile), cfg.KeyFile+"-cert.pub"), " "), result)
+		assert.Equal(t, fmt.Sprintf("-i %s 123@host.grafana.net -p 22 -R 0 -vv -o UserKnownHostsFile=%s -o CertificateFile=%s -o ServerAliveInterval=15 -vvv -o testoption=2 -o PermitRemoteOpen='host:123 host:456'", cfg.KeyFile, path.Join(cfg.KeyFileDir(), ssh.KnownHostsFile), cfg.KeyFile+"-cert.pub"), strings.Join(result, " "))
 
 	})
 }

--- a/pkg/ssh/ssh_test.go
+++ b/pkg/ssh/ssh_test.go
@@ -125,14 +125,14 @@ func TestClient_SSHArgs(t *testing.T) {
 		cfg.SSHFlags = []string{
 			"-vvv",
 			"-o testoption=2",
-			"-o PermitRemoteOpen='host:123 host:456'",
+			"-o PermitRemoteOpen=host:123 host:456",
 		}
 
 		sshClient := newTestClient(t, cfg)
 		result, err := sshClient.SSHFlagsFromConfig()
 
 		assert.Nil(t, err)
-		assert.Equal(t, fmt.Sprintf("-i %s 123@host.grafana.net -p 22 -R 0 -vv -o UserKnownHostsFile=%s -o CertificateFile=%s -o ServerAliveInterval=15 -vvv -o testoption=2 -o PermitRemoteOpen='host:123 host:456'", cfg.KeyFile, path.Join(cfg.KeyFileDir(), ssh.KnownHostsFile), cfg.KeyFile+"-cert.pub"), strings.Join(result, " "))
+		assert.Equal(t, fmt.Sprintf("-i %s 123@host.grafana.net -p 22 -R 0 -vv -o UserKnownHostsFile=%s -o CertificateFile=%s -o ServerAliveInterval=15 -vvv -o testoption=2 -o PermitRemoteOpen=host:123 host:456", cfg.KeyFile, path.Join(cfg.KeyFileDir(), ssh.KnownHostsFile), cfg.KeyFile+"-cert.pub"), strings.Join(result, " "))
 
 	})
 }

--- a/pkg/ssh/ssh_test.go
+++ b/pkg/ssh/ssh_test.go
@@ -132,7 +132,26 @@ func TestClient_SSHArgs(t *testing.T) {
 		result, err := sshClient.SSHFlagsFromConfig()
 
 		assert.Nil(t, err)
-		assert.Equal(t, fmt.Sprintf("-i %s 123@host.grafana.net -p 22 -R 0 -vv -o UserKnownHostsFile=%s -o CertificateFile=%s -o ServerAliveInterval=15 -vvv -o testoption=2 -o PermitRemoteOpen=host:123 host:456", cfg.KeyFile, path.Join(cfg.KeyFileDir(), ssh.KnownHostsFile), cfg.KeyFile+"-cert.pub"), strings.Join(result, " "))
+		expected := []string{
+			"-i",
+			cfg.KeyFile,
+			"123@host.grafana.net",
+			"-p",
+			"22",
+			"-R",
+			"0",
+			"-vv",
+			"-o",
+			fmt.Sprintf("UserKnownHostsFile=%s", path.Join(cfg.KeyFileDir(), ssh.KnownHostsFile)),
+			"-o",
+			fmt.Sprintf("CertificateFile=%s", cfg.KeyFile+"-cert.pub"),
+			"-o",
+			"ServerAliveInterval=15",
+			"-vvv",
+			"-o testoption=2",
+			"-o PermitRemoteOpen=host:123 host:456",
+		}
+		assert.Equal(t, expected, result)
 
 	})
 }


### PR DESCRIPTION
This fixes an error where passing the flag `-ssh-flag='-o PermitRemoteOpen=host:123 host:456'

Currently, this is split into too many strings, whereas we want `PermitRemoteOpen=host:123 host:456` to stay as one string to get parsed correctly by openssh.

It turns out we don't need to flatten these flags when they're passed in.

The structure of the flags passed to openssh is now

```
[]string{ ...  \"-o PermitRemoteOpen=prometheus.demo.do.prometheus.io:443 localhost:9090\"}
```

whereas it used to be

```
[]string{ ... \"-o\", \"PermitRemoteOpen=prometheus.demo.do.prometheus.io:443\", \"localhost:9090\"}
```

(the splitting of the two host:port combos is the important part, the split of the `-o` is something i found to be not required when debugging this)

We can successfullt parse this as an ssh-flag with 
```
-ssh-flag='-o PermitRemoteOpen=prometheus.demo.do.prometheus.io:443 localhost:9090'
```