### PR TITLE
Add ability to change ssh log verbosity

### DIFF
--- a/pkg/ssh/ssh_test.go
+++ b/pkg/ssh/ssh_test.go
@@ -154,4 +154,31 @@ func TestClient_SSHArgs(t *testing.T) {
 		assert.Equal(t, expected, result)
 
 	})
+
+	t.Run("allow updating the log verbosity", func(t *testing.T) {
+		cfg := ssh.DefaultConfig()
+		cfg.LogLevel = 0
+
+		sshClient := newTestClient(t, cfg)
+		result, err := sshClient.SSHFlagsFromConfig()
+
+		assert.Nil(t, err)
+		expected := []string{
+			"-i",
+			cfg.KeyFile,
+			"@localhost",
+			"-p",
+			"22",
+			"-R",
+			"0",
+			"",
+			"-o",
+			fmt.Sprintf("UserKnownHostsFile=%s", path.Join(cfg.KeyFileDir(), ssh.KnownHostsFile)),
+			"-o",
+			fmt.Sprintf("CertificateFile=%s", cfg.KeyFile+"-cert.pub"),
+			"-o",
+			"ServerAliveInterval=15",
+		}
+		assert.Equal(t, expected, result)
+	})
 }


### PR DESCRIPTION
This PR adds a flag, `log-level`, to the pdc-agent to enable the user to change the verbosity level from debug1 to debug3 or completely disable it. 

Currently, since we hard code "-vv", that's the verbosity level used. When I override it with the ssh-flag option, it still used the default verbosity. Rather than searching through the ssh flags given to see if it's overridden, I added a new flag so that it can also be disabled.