### PR TITLE
Add retries to pdc-agent key signing request

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,8 @@ require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/go-logfmt/logfmt v0.5.1 // indirect
 	github.com/golang/protobuf v1.5.3 // indirect
+	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
+	github.com/hashicorp/go-retryablehttp v0.7.4 // indirect
 	github.com/kr/text v0.2.0 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.4 // indirect
 	github.com/pkg/errors v0.9.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -19,6 +19,11 @@ github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
 github.com/grafana/dskit v0.0.0-20230104190044-356662f98a76 h1:kOg6X64tXsiong01rM04Az8aaJoR1kJRJ60RtwClULs=
 github.com/grafana/dskit v0.0.0-20230104190044-356662f98a76/go.mod h1:jH702wuweJhQMi17e1bb1U3GRlnyz+n2wCuohshSX40=
+github.com/hashicorp/go-cleanhttp v0.5.2 h1:035FKYIWjmULyFRBKPs8TBQoi0x6d9G4xc9neXJWAZQ=
+github.com/hashicorp/go-cleanhttp v0.5.2/go.mod h1:kO/YDlP8L1346E6Sodw+PrpBSV4/SoxCXGY6BqNFT48=
+github.com/hashicorp/go-hclog v0.9.2/go.mod h1:5CU+agLiy3J7N7QjHK5d05KxGsuXiQLrjA0H7acj2lQ=
+github.com/hashicorp/go-retryablehttp v0.7.4 h1:ZQgVdpTdAL7WpMIwLzCfbalOcSUdkDZnpUv3/+BxzFA=
+github.com/hashicorp/go-retryablehttp v0.7.4/go.mod h1:Jy/gPYAdjqffZ/yFGCFV2doI5wjtH1ewM9u8iYVjtX8=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
 github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
@@ -43,6 +48,7 @@ github.com/rogpeppe/go-internal v1.9.0 h1:73kH8U+JUqXU8lRuOHeVHaa/SZPifC7BkcraZV
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
+github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=

--- a/pkg/pdc/client.go
+++ b/pkg/pdc/client.go
@@ -16,8 +16,9 @@ import (
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
-
 	"github.com/grafana/pdc-agent/pkg/httpclient"
+	"github.com/hashicorp/go-retryablehttp"
+
 	"golang.org/x/crypto/ssh"
 )
 
@@ -33,6 +34,7 @@ type Config struct {
 	Token           string
 	HostedGrafanaID string
 	URL             *url.URL
+	RetryMax        int
 }
 
 func (cfg *Config) RegisterFlags(fs *flag.FlagSet) {
@@ -92,9 +94,19 @@ func NewClient(cfg *Config, logger log.Logger) (Client, error) {
 		return nil, errors.New("-api-url cannot be nil")
 	}
 
+	rc := retryablehttp.NewClient()
+	if cfg.RetryMax != 0 {
+		rc.RetryMax = cfg.RetryMax
+	}
+	rc.Logger = &logAdapter{logger}
+	rc.CheckRetry = retryablehttp.ErrorPropagatedRetryPolicy
+	hc := rc.StandardClient()
+
+	hc.Transport = httpclient.UserAgentTransport(hc.Transport)
+
 	return &pdcClient{
 		cfg:        cfg,
-		httpClient: &http.Client{Transport: httpclient.UserAgentTransport(nil)},
+		httpClient: hc,
 		logger:     logger,
 	}, nil
 }
@@ -177,4 +189,32 @@ func (c *pdcClient) call(ctx context.Context, method, rpath string, params map[s
 		level.Error(c.logger).Log("msg", "unknown response from PDC API", "code", resp.StatusCode)
 		return respB, ErrInternal
 	}
+}
+
+type logAdapter struct {
+	l log.Logger
+}
+
+var _ retryablehttp.LeveledLogger = (*logAdapter)(nil)
+
+func (l *logAdapter) Debug(msg string, kv ...interface{}) {
+	keyvals := []interface{}{"msg", msg}
+	keyvals = append(keyvals, kv...)
+	level.Debug(l.l).Log(keyvals...)
+}
+
+func (l *logAdapter) Info(msg string, kv ...interface{}) {
+	keyvals := []interface{}{"msg", msg}
+	keyvals = append(keyvals, kv...)
+	level.Info(l.l).Log(keyvals...)
+}
+func (l *logAdapter) Warn(msg string, kv ...interface{}) {
+	keyvals := []interface{}{"msg", msg}
+	keyvals = append(keyvals, kv...)
+	level.Warn(l.l).Log(keyvals...)
+}
+func (l *logAdapter) Error(msg string, kv ...interface{}) {
+	keyvals := []interface{}{"msg", msg}
+	keyvals = append(keyvals, kv...)
+	level.Error(l.l).Log(keyvals...)
 }


### PR DESCRIPTION
This PR adds exponential backoff to the PDC client, which is used for making key signing requests to the PDC API.

closes #29 

We're using the default timings,  with a 1s initial wait, which doubles every time. Default MaxRetry is 4. The backoff behaviour looks like the following:

```
level=debug caller=client.go:203 msg="performing request" method=POST url=https://private-datasource-connect-api-dev-us-central-01.grafana-dev.net/pdc/api/v1/sign-public-key
level=debug caller=client.go:203 msg="retrying request" request="POST https://private-datasource-connect-api-dev-us-central-01.grafana-dev.net/pdc/api/v1/sign-public-key (status: 500)" timeout=1s remaining=4
level=debug caller=client.go:203 msg="retrying request" request="POST https://private-datasource-connect-api-dev-us-central-01.grafana-dev.net/pdc/api/v1/sign-public-key (status: 500)" timeout=2s remaining=3
level=debug caller=client.go:203 msg="retrying request" request="POST https://private-datasource-connect-api-dev-us-central-01.grafana-dev.net/pdc/api/v1/sign-public-key (status: 500)" timeout=4s remaining=2
level=debug caller=client.go:203 msg="retrying request" request="POST https://private-datasource-connect-api-dev-us-central-01.grafana-dev.net/pdc/api/v1/sign-public-key (status: 500)" timeout=8s remaining=1
level=error caller=client.go:174 msg="error making request to PDC API" err="Post \"https://private-datasource-connect-api-dev-us-central-01.grafana-dev.net/pdc/api/v1/sign-public-key\": POST https://private-datasource-connect-api-dev-us-central-01.grafana-dev.net/pdc/api/v1/sign-public-key giving up after 5 attempt(s): unexpected HTTP status 500 Internal Server Error"
level=error caller=ssh.go:102 msg="could not check or generate certificate" error="failed to generate new certificate: key signing request failed: internal error"
```