### PR TITLE
Handle when -log-level is set to 0

### DIFF
--- a/pkg/ssh/ssh.go
+++ b/pkg/ssh/ssh.go
@@ -160,10 +160,13 @@ func (s *Client) SSHFlagsFromConfig() ([]string, error) {
 		"-p",
 		fmt.Sprintf("%d", s.cfg.Port),
 		"-R", "0",
-		logLevelFlag,
 		"-o", fmt.Sprintf("UserKnownHostsFile=%s/%s", keyFileDir, KnownHostsFile),
 		"-o", fmt.Sprintf("CertificateFile=%s-cert.pub", s.cfg.KeyFile),
 		"-o", "ServerAliveInterval=15",
+	}
+
+	if logLevelFlag != "" {
+		result = append(result, logLevelFlag)
 	}
 
 	for _, f := range s.cfg.SSHFlags {

--- a/pkg/ssh/ssh_test.go
+++ b/pkg/ssh/ssh_test.go
@@ -171,7 +171,6 @@ func TestClient_SSHArgs(t *testing.T) {
 			"22",
 			"-R",
 			"0",
-			"",
 			"-o",
 			fmt.Sprintf("UserKnownHostsFile=%s", path.Join(cfg.KeyFileDir(), ssh.KnownHostsFile)),
 			"-o",
@@ -180,5 +179,30 @@ func TestClient_SSHArgs(t *testing.T) {
 			"ServerAliveInterval=15",
 		}
 		assert.Equal(t, expected, result)
+
+		cfg.LogLevel = 2
+
+		sshClient = newTestClient(t, cfg)
+		result, err = sshClient.SSHFlagsFromConfig()
+
+		assert.Nil(t, err)
+		expected = []string{
+			"-i",
+			cfg.KeyFile,
+			"@localhost",
+			"-p",
+			"22",
+			"-R",
+			"0",
+			"-o",
+			fmt.Sprintf("UserKnownHostsFile=%s", path.Join(cfg.KeyFileDir(), ssh.KnownHostsFile)),
+			"-o",
+			fmt.Sprintf("CertificateFile=%s", cfg.KeyFile+"-cert.pub"),
+			"-o",
+			"ServerAliveInterval=15",
+			"-vv",
+		}
+		assert.Equal(t, expected, result)
+
 	})
 }

--- a/pkg/ssh/ssh_test.go
+++ b/pkg/ssh/ssh_test.go
@@ -96,7 +96,7 @@ func TestClient_SSHArgs(t *testing.T) {
 		result, err := sshClient.SSHFlagsFromConfig()
 
 		assert.Nil(t, err)
-		assert.Equal(t, strings.Split(fmt.Sprintf("-i %s 123@host.grafana.net -p 22 -R 0 -vv -o UserKnownHostsFile=%s -o CertificateFile=%s -o ServerAliveInterval=15", cfg.KeyFile, path.Join(cfg.KeyFileDir(), ssh.KnownHostsFile), cfg.KeyFile+"-cert.pub"), " "), result)
+		assert.Equal(t, strings.Split(fmt.Sprintf("-i %s 123@host.grafana.net -p 22 -R 0 -o UserKnownHostsFile=%s -o CertificateFile=%s -o ServerAliveInterval=15 -vv", cfg.KeyFile, path.Join(cfg.KeyFileDir(), ssh.KnownHostsFile), cfg.KeyFile+"-cert.pub"), " "), result)
 	})
 
 	t.Run("legacy args (deprecated)", func(t *testing.T) {
@@ -140,13 +140,13 @@ func TestClient_SSHArgs(t *testing.T) {
 			"22",
 			"-R",
 			"0",
-			"-vv",
 			"-o",
 			fmt.Sprintf("UserKnownHostsFile=%s", path.Join(cfg.KeyFileDir(), ssh.KnownHostsFile)),
 			"-o",
 			fmt.Sprintf("CertificateFile=%s", cfg.KeyFile+"-cert.pub"),
 			"-o",
 			"ServerAliveInterval=15",
+			"-vv",
 			"-vvv",
 			"-o testoption=2",
 			"-o PermitRemoteOpen=host:123 host:456",


### PR DESCRIPTION
We currently set an empty string into the ssh command when `-log-level` is set to 0, which creates an invalid command.

This PR makes adjusts how we add the optional log level, so that it avoids adding an empty string.