### PR TITLE
Ensure agent reconnects when the API is unreachable

### DIFF
--- a/pkg/ssh/ssh.go
+++ b/pkg/ssh/ssh.go
@@ -137,7 +137,6 @@ func (s *Client) starting(ctx context.Context) error {
 				err := s.km.CreateKeys(ctx)
 				if err != nil {
 					level.Error(s.logger).Log("msg", "could not check or generate certificate", "error", err)
-					break
 				}
 			}
 


### PR DESCRIPTION
Ensure the agent attempts to reconnect if the API is unreachable for a short period of time.

```
level=error caller=client.go:177 msg="error making request to PDC API" err="Post \"https://private-datasource-connect-api-<...>.net/pdc/api/v1/sign-public-key\": POST https://private-datasource-connect-api-<...>.grafana-dev.net/pdc/api/v1/sign-public-key giving up after 5 attempt(s): unexpected HTTP status 502 Bad Gateway"
level=error caller=ssh.go:139 msg="could not check or generate certificate" error="ensuring certificate exists: failed to generate new certificate: key signing request failed: internal error 
```

