### PR TITLE
Deprecate network flag

### DIFF
--- a/pkg/pdc/client.go
+++ b/pkg/pdc/client.go
@@ -33,15 +33,15 @@ var (
 type Config struct {
 	Token           string
 	HostedGrafanaID string
-	Network         string
 	URL             *url.URL
 	RetryMax        int
 }
 
 func (cfg *Config) RegisterFlags(fs *flag.FlagSet) {
+	var deprecated string
 	fs.StringVar(&cfg.Token, "token", "", "The token to use to authenticate with Grafana Cloud. It must have the pdc-signing:write scope")
 	fs.StringVar(&cfg.HostedGrafanaID, "gcloud-hosted-grafana-id", "", "The ID of the Hosted Grafana instance to connect to")
-	fs.StringVar(&cfg.Network, "network", "", "The name of the PDC network to connect to")
+	fs.StringVar(&deprecated, "network", "", "DEPRECATED: The name of the PDC network to connect to")
 }
 
 // Client is a PDC API client
@@ -122,7 +122,6 @@ type pdcClient struct {
 func (c *pdcClient) SignSSHKey(ctx context.Context, key []byte) (*SigningResponse, error) {
 	resp, err := c.call(ctx, http.MethodPost, "/pdc/api/v1/sign-public-key", nil, map[string]string{
 		"publicKey": string(key),
-		"network":   c.cfg.Network,
 	})
 	if err != nil {
 		return nil, err

--- a/pkg/ssh/keymanager.go
+++ b/pkg/ssh/keymanager.go
@@ -210,9 +210,6 @@ func (km KeyManager) argumentsHashIsDifferent(hash string) bool {
 // argumentsHash returns a hash of the values that end up in the principals field of the certificate.
 func (km KeyManager) argumentsHash() string {
 	value := km.cfg.PDC.HostedGrafanaID
-	if km.cfg.PDC.Network != "" {
-		value = fmt.Sprintf("%s/%s", value, km.cfg.PDC.Network)
-	}
 	return fmt.Sprintf("%x", sha256.Sum256([]byte(value)))
 }
 

--- a/pkg/ssh/keymanager_test.go
+++ b/pkg/ssh/keymanager_test.go
@@ -107,7 +107,7 @@ func TestKeyManager_EnsureKeysExist(t *testing.T) {
 				_ = os.WriteFile(cfg.KeyFile+".pub", pubKey, 0644)
 				_ = os.WriteFile(cfg.KeyFile+"-cert.pub", cert, 0644)
 				_ = os.WriteFile(path.Join(cfg.KeyFileDir(), ssh.KnownHostsFile), kh, 0644)
-				_ = os.WriteFile(cfg.KeyFile+"_hash", []byte("bd3d1bc9966d7c3636cc5ab72b1410f76500a01ef7605edb95214899fc1474a4"), 0644)
+				_ = os.WriteFile(cfg.KeyFile+"_hash", []byte("6b86b273ff34fce19d6b804eff5a3f5747ada4eaa22f1d49c01e52ddb7875b4b"), 0644)
 			},
 			assertFn:           assertExpectedFiles,
 			wantSigningRequest: true,
@@ -121,7 +121,7 @@ func TestKeyManager_EnsureKeysExist(t *testing.T) {
 				_ = os.WriteFile(cfg.KeyFile+".pub", []byte("not a public key"), 0644)
 				_ = os.WriteFile(cfg.KeyFile+"-cert.pub", cert, 0644)
 				_ = os.WriteFile(path.Join(cfg.KeyFileDir(), ssh.KnownHostsFile), kh, 0644)
-				_ = os.WriteFile(cfg.KeyFile+"_hash", []byte("bd3d1bc9966d7c3636cc5ab72b1410f76500a01ef7605edb95214899fc1474a4"), 0644)
+				_ = os.WriteFile(cfg.KeyFile+"_hash", []byte("6b86b273ff34fce19d6b804eff5a3f5747ada4eaa22f1d49c01e52ddb7875b4b"), 0644)
 			},
 			assertFn:           assertExpectedFiles,
 			wantSigningRequest: true,
@@ -135,7 +135,7 @@ func TestKeyManager_EnsureKeysExist(t *testing.T) {
 				_ = os.WriteFile(cfg.KeyFile+".pub", pubKey, 0644)
 				_ = os.WriteFile(cfg.KeyFile+"-cert.pub", []byte("invalid cert"), 0644)
 				_ = os.WriteFile(path.Join(cfg.KeyFileDir(), ssh.KnownHostsFile), kh, 0644)
-				_ = os.WriteFile(cfg.KeyFile+"_hash", []byte("bd3d1bc9966d7c3636cc5ab72b1410f76500a01ef7605edb95214899fc1474a4"), 0644)
+				_ = os.WriteFile(cfg.KeyFile+"_hash", []byte("6b86b273ff34fce19d6b804eff5a3f5747ada4eaa22f1d49c01e52ddb7875b4b"), 0644)
 			},
 			assertFn:           assertExpectedFiles,
 			wantSigningRequest: true,
@@ -149,7 +149,7 @@ func TestKeyManager_EnsureKeysExist(t *testing.T) {
 				_ = os.WriteFile(cfg.KeyFile+".pub", pubKey, 0644)
 				_ = os.WriteFile(cfg.KeyFile+"-cert.pub", cert, 0644)
 				_ = os.WriteFile(path.Join(cfg.KeyFileDir(), ssh.KnownHostsFile), []byte("invalid known_hosts"), 0644)
-				_ = os.WriteFile(cfg.KeyFile+"_hash", []byte("bd3d1bc9966d7c3636cc5ab72b1410f76500a01ef7605edb95214899fc1474a4"), 0644)
+				_ = os.WriteFile(cfg.KeyFile+"_hash", []byte("6b86b273ff34fce19d6b804eff5a3f5747ada4eaa22f1d49c01e52ddb7875b4b"), 0644)
 			},
 			wantSigningRequest: true,
 			assertFn:           assertExpectedFiles,
@@ -168,7 +168,7 @@ func TestKeyManager_EnsureKeysExist(t *testing.T) {
 				_ = os.WriteFile(cfg.KeyFile+".pub", pubKey, 0644)
 				_ = os.WriteFile(cfg.KeyFile+"-cert.pub", cert, 0644)
 				_ = os.WriteFile(path.Join(cfg.KeyFileDir(), ssh.KnownHostsFile), kh, 0644)
-				_ = os.WriteFile(cfg.KeyFile+"_hash", []byte("bd3d1bc9966d7c3636cc5ab72b1410f76500a01ef7605edb95214899fc1474a4"), 0644)
+				_ = os.WriteFile(cfg.KeyFile+"_hash", []byte("6b86b273ff34fce19d6b804eff5a3f5747ada4eaa22f1d49c01e52ddb7875b4b"), 0644)
 			},
 			wantSigningRequest: false,
 			assertFn: func(t *testing.T, cfg *ssh.Config) {
@@ -246,7 +246,7 @@ func TestKeyManager_EnsureKeysExist(t *testing.T) {
 			ctx := context.Background()
 
 			// create default configs
-			pdcCfg := pdc.Config{HostedGrafanaID: "1", Network: "default"}
+			pdcCfg := pdc.Config{HostedGrafanaID: "1"}
 			cfg := ssh.DefaultConfig()
 			cfg.PDC = pdcCfg
 

--- a/pkg/ssh/ssh.go
+++ b/pkg/ssh/ssh.go
@@ -170,9 +170,6 @@ func (s *Client) SSHFlagsFromConfig() ([]string, error) {
 
 	gwURL := s.cfg.URL
 	user := fmt.Sprintf("%s@%s", s.cfg.PDC.HostedGrafanaID, gwURL.String())
-	if s.cfg.PDC.Network != "" {
-		user = fmt.Sprintf("%s/%s@%s", s.cfg.PDC.HostedGrafanaID, s.cfg.PDC.Network, gwURL.String())
-	}
 
 	result := []string{
 		"-i",


### PR DESCRIPTION
We added this flag in preparation for a new feature, but a change in the implementation means its no longer required. Deprecate the flag just in case its in use somewhere.