### PR TITLE
added retrymax flag to override the default RetryMax of 4

### DIFF
--- a/pkg/pdc/client.go
+++ b/pkg/pdc/client.go
@@ -42,6 +42,7 @@ func (cfg *Config) RegisterFlags(fs *flag.FlagSet) {
 	fs.StringVar(&cfg.Token, "token", "", "The token to use to authenticate with Grafana Cloud. It must have the pdc-signing:write scope")
 	fs.StringVar(&cfg.HostedGrafanaID, "gcloud-hosted-grafana-id", "", "The ID of the Hosted Grafana instance to connect to")
 	fs.StringVar(&deprecated, "network", "", "DEPRECATED: The name of the PDC network to connect to")
+	fs.IntVar(&cfg.RetryMax, "retrymax", 4, "The max num of retries for http requests")
 }
 
 // Client is a PDC API client


### PR DESCRIPTION
Adds the `--retrymax` flag to override the default RetryMax of 4

This is a bit redundant for container use after #39 (as pdc will exits itself, and cause the container to restart), it was essential for my environment before that PR to ensure it will retry more than 4 times if there is a problem. 

If you are using pdc binary, then this will be quite useful.