### PR TITLE
add openssh version validation

### DIFF
--- a/pkg/ssh/ssh.go
+++ b/pkg/ssh/ssh.go
@@ -266,7 +266,7 @@ func validateSSHVersion(ctx context.Context, logger log.Logger, sshCmd string) e
 	}
 
 	version := string(out)
-	major, minor, err := ParseSSHVersion(ctx, version)
+	major, minor, err := ParseSSHVersion(version)
 	if err != nil {
 		level.Warn(logger).Log("msg", "unable to retrieve SSH version for validation", "err", err)
 		return nil
@@ -277,7 +277,7 @@ func validateSSHVersion(ctx context.Context, logger log.Logger, sshCmd string) e
 
 var sshVersionRegexp = regexp.MustCompile(`OpenSSH_(\d+)\.(\d+)`)
 
-func ParseSSHVersion(ctx context.Context, version string) (int, int, error) {
+func ParseSSHVersion(version string) (int, int, error) {
 	matches := sshVersionRegexp.FindStringSubmatch(version)
 	if len(matches) < 3 {
 		return 0, 0, fmt.Errorf("failed to parse OpenSSH version")

--- a/pkg/ssh/ssh.go
+++ b/pkg/ssh/ssh.go
@@ -103,7 +103,7 @@ func (s *Client) starting(ctx context.Context) error {
 
 	if !s.cfg.SkipSSHValidation {
 		if err := validateSSHVersion(ctx, s.SSHCmd); err != nil {
-			return fmt.Errorf("failed to check ssh version: %w", err)
+			return fmt.Errorf("failed to validate ssh version: %w", err)
 		}
 	}
 

--- a/pkg/ssh/ssh.go
+++ b/pkg/ssh/ssh.go
@@ -275,9 +275,10 @@ func validateSSHVersion(ctx context.Context, logger log.Logger, sshCmd string) e
 	return RequireSSHVersionAbove9_2(major, minor)
 }
 
+var sshVersionRegexp = regexp.MustCompile(`OpenSSH_(\d+)\.(\d+)`)
+
 func ParseSSHVersion(ctx context.Context, version string) (int, int, error) {
-	re := regexp.MustCompile(`OpenSSH_(\d+)\.(\d+)`)
-	matches := re.FindStringSubmatch(version)
+	matches := sshVersionRegexp.FindStringSubmatch(version)
 	if len(matches) < 3 {
 		return 0, 0, fmt.Errorf("failed to parse OpenSSH version")
 	}

--- a/pkg/ssh/ssh.go
+++ b/pkg/ssh/ssh.go
@@ -9,7 +9,9 @@ import (
 	"os"
 	"os/exec"
 	"path"
+	"regexp"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -25,13 +27,14 @@ import (
 type Config struct {
 	Args []string // deprecated
 
-	KeyFile    string
-	SSHFlags   []string // Additional flags to be passed to ssh(1). e.g. --ssh-flag="-vvv" --ssh-flag="-L 80:localhost:80"
-	Port       int
-	LogLevel   int
-	PDC        pdc.Config
-	LegacyMode bool
-	URL        *url.URL
+	KeyFile           string
+	SSHFlags          []string // Additional flags to be passed to ssh(1). e.g. --ssh-flag="-vvv" --ssh-flag="-L 80:localhost:80"
+	Port              int
+	LogLevel          int
+	PDC               pdc.Config
+	LegacyMode        bool
+	SkipSSHValidation bool
+	URL               *url.URL
 }
 
 // DefaultConfig returns a Config with some sensible defaults set
@@ -59,6 +62,7 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	if cfg.LogLevel > 3 {
 		cfg.LogLevel = def.LogLevel
 	}
+	f.BoolVar(&cfg.SkipSSHValidation, "skip-ssh-validation", false, "Ignore openssh minimum version constraints.")
 	f.Func("ssh-flag", "Additional flags to be passed to ssh. Can be set more than once.", cfg.addSSHFlag)
 }
 
@@ -96,6 +100,12 @@ func NewClient(cfg *Config, logger log.Logger, km *KeyManager) *Client {
 
 func (s *Client) starting(ctx context.Context) error {
 	level.Info(s.logger).Log("msg", "starting ssh client")
+
+	if !s.cfg.SkipSSHValidation {
+		if err := validateSSHVersion(ctx, s.SSHCmd); err != nil {
+			return fmt.Errorf("failed to check ssh version: %w", err)
+		}
+	}
 
 	// check keys and cert validity before start, create new cert if required
 	// This will exit if it fails, rather than endlessly retrying to sign keys.
@@ -232,4 +242,44 @@ func extractOptionFromFlag(flag string) (string, string, error) {
 		return "", "", errors.New("invalid ssh option format, expecting '-o Name=string'")
 	}
 	return oParts[0], oParts[1], nil
+}
+
+// openssh must be running 9.2 or above
+// checks version in format OpenSSH_{MAJOR}.{MINOR}
+func validateSSHVersion(ctx context.Context, sshCmd string) error {
+	version, err := getSSHVersion(ctx, sshCmd)
+	if err != nil {
+		return err
+	}
+	return RequireSSHVersionAbove9_2(version)
+}
+
+func getSSHVersion(ctx context.Context, sshCmd string) (string, error) {
+	out, err := exec.CommandContext(ctx, sshCmd, "-V").CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("failed to run ssh -V command: %w", err)
+	}
+	return string(out), nil
+}
+
+func RequireSSHVersionAbove9_2(version string) error {
+	re := regexp.MustCompile(`OpenSSH_(\d+)\.(\d+)`)
+	matches := re.FindStringSubmatch(version)
+	if len(matches) < 3 {
+		return fmt.Errorf("failed to parse OpenSSH version")
+	}
+
+	major, err := strconv.Atoi(matches[1])
+	if err != nil {
+		return fmt.Errorf("failed to parse OpenSSH major version")
+	}
+	minor, err := strconv.Atoi(matches[2])
+	if err != nil {
+		return fmt.Errorf("failed to parse OpenSSH minor version")
+	}
+
+	if major > 9 || (major == 9 && minor >= 2) {
+		return nil
+	}
+	return fmt.Errorf("OpenSSH version must be greater or equal to 9.2, current version: %d.%d", major, minor)
 }

--- a/pkg/ssh/ssh_test.go
+++ b/pkg/ssh/ssh_test.go
@@ -310,7 +310,7 @@ func TestSSHVersionValidation(t *testing.T) {
 	}
 	for _, tc := range testcases {
 		t.Run(tc.version, func(t *testing.T) {
-			major, minor, err := ssh.ParseSSHVersion(context.Background(), tc.version)
+			major, minor, err := ssh.ParseSSHVersion(tc.version)
 
 			if tc.valid {
 				require.NoError(t, err)

--- a/pkg/ssh/ssh_test.go
+++ b/pkg/ssh/ssh_test.go
@@ -310,10 +310,14 @@ func TestSSHVersionValidation(t *testing.T) {
 	}
 	for _, tc := range testcases {
 		t.Run(tc.version, func(t *testing.T) {
-			err := ssh.RequireSSHVersionAbove9_2(tc.version)
+			major, minor, err := ssh.ParseSSHVersion(context.Background(), tc.version)
+
 			if tc.valid {
 				require.NoError(t, err)
+				err := ssh.RequireSSHVersionAbove9_2(major, minor)
+				require.NoError(t, err)
 			} else {
+				err := ssh.RequireSSHVersionAbove9_2(major, minor)
 				require.Error(t, err)
 			}
 		})

--- a/pkg/ssh/ssh_test.go
+++ b/pkg/ssh/ssh_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/grafana/pdc-agent/pkg/pdc"
 	"github.com/grafana/pdc-agent/pkg/ssh"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	gossh "golang.org/x/crypto/ssh"
 )
 
@@ -109,6 +110,8 @@ func newTestClient(t *testing.T, cfg *ssh.Config, mockCmd bool) *ssh.Client {
 	if cfg.URL == nil {
 		cfg.URL = mustParseURL("localhost")
 	}
+
+	cfg.SkipSSHValidation = true
 
 	dir := t.TempDir()
 	cfg.KeyFile = path.Join(dir, "test_cert")
@@ -265,6 +268,57 @@ func TestClient_SSHArgs(t *testing.T) {
 		assert.NotNil(t, err)
 		assert.Equal(t, err.Error(), "invalid ssh option format, expecting '-o Name=string'")
 	})
+}
+
+func TestSSHVersionValidation(t *testing.T) {
+	testcases := []struct {
+		version string
+		valid   bool
+	}{
+		{
+			version: "TestSSH_9.2",
+			valid:   false,
+		},
+		{
+			version: "OpenSSH_test",
+			valid:   false,
+		},
+		{
+			version: "OpenSSH_8.9",
+			valid:   false,
+		},
+		{
+			version: "OpenSSH_9.1 test ssh metadata",
+			valid:   false,
+		},
+		{
+			version: "OpenSSH_9.2, test ssh metadata",
+			valid:   true,
+		},
+		{
+			version: "OpenSSH_9.200p1, test ssh metadata",
+			valid:   true,
+		},
+		{
+			version: "OpenSSH_9.2p1",
+			valid:   true,
+		},
+		{
+			version: "OpenSSH_19.1p1, test ssh metadata",
+			valid:   true,
+		},
+	}
+	for _, tc := range testcases {
+		t.Run(tc.version, func(t *testing.T) {
+			err := ssh.RequireSSHVersionAbove9_2(tc.version)
+			if tc.valid {
+				require.NoError(t, err)
+			} else {
+				require.Error(t, err)
+			}
+		})
+	}
+
 }
 
 type mockPDCClient struct {


### PR DESCRIPTION
Fixes https://github.com/grafana/pdc-agent/issues/44

The minimum version constraint is documented here:
https://grafana.com/docs/grafana-cloud/connect-externally-hosted/private-data-source-connect/configure-pdc/