### PR TITLE
development: make it easier to run the pdc agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@ The Grafana Private Datasource Connect Agent allows connecting private datasourc
 
 Follow installation and running instructions in the [Grafana Labs Documentation](https://grafana.com/docs/grafana-cloud/data-configuration/configure-private-datasource-connect/)
 
+## DEV flags
+
+Flags prefixed with `-dev` are used for local development and can be removed at any time.
+
 ## Releasing
 
 Create public releases with `gh release create vX.X.X --generate-notes`

--- a/pkg/ssh/keymanager.go
+++ b/pkg/ssh/keymanager.go
@@ -210,6 +210,11 @@ func (km KeyManager) argumentsHashIsDifferent(hash string) bool {
 // argumentsHash returns a hash of the values that end up in the principals field of the certificate.
 func (km KeyManager) argumentsHash() string {
 	value := km.cfg.PDC.HostedGrafanaID
+
+	if km.cfg.PDC.DevNetwork != "" {
+		value = fmt.Sprintf("%s/%s", value, km.cfg.PDC.DevNetwork)
+	}
+
 	return fmt.Sprintf("%x", sha256.Sum256([]byte(value)))
 }
 


### PR DESCRIPTION
- Makes it easier to run the pdc-agent for local development

The command to run the agent looks like this:
```sh
 go run ./cmd/pdc/main.go -token gcloud-token -gcloud-hosted-grafana-id tunnel-demo -dev-mode -dev-network network1
```