### PR TITLE
output agent info on startup

### DIFF
--- a/cmd/pdc/main.go
+++ b/cmd/pdc/main.go
@@ -1,13 +1,18 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"flag"
 	"fmt"
 	"net/url"
 	"os"
+	"os/exec"
 	"os/signal"
+	"runtime"
+	"strings"
 	"syscall"
+	"time"
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
@@ -16,6 +21,19 @@ import (
 	"github.com/grafana/pdc-agent/pkg/pdc"
 	"github.com/grafana/pdc-agent/pkg/ssh"
 )
+
+// Values set by goreleaser during the build process using ldflags.
+// https://goreleaser.com/cookbooks/using-main.version/
+var (
+	// Current Git tag (the v prefix is stripped) or the name of the snapshot, if you're using the --snapshot flag
+	version string
+	// Current git commit SHA
+	commit string
+	// Date in the RFC3339 format
+	date string
+)
+
+const logLevelinfo = "info"
 
 type mainFlags struct {
 	PrintHelp bool
@@ -31,10 +49,29 @@ type mainFlags struct {
 
 func (mf *mainFlags) RegisterFlags(fs *flag.FlagSet) {
 	fs.BoolVar(&mf.PrintHelp, "h", false, "Print help")
-	fs.StringVar(&mf.LogLevel, "log.level", "info", `"debug", "info", "warn" or "error"`)
+	fs.StringVar(&mf.LogLevel, "log.level", logLevelinfo, `"debug", "info", "warn" or "error"`)
 	fs.StringVar(&mf.Cluster, "cluster", "", "the PDC cluster to connect to use")
 	fs.StringVar(&mf.Domain, "domain", "grafana.net", "the domain of the PDC cluster")
 	fs.BoolVar(&mf.DevMode, "dev-mode", false, "[DEVELOPMENT ONLY] run the agent in development mode")
+}
+
+// Tries to get the openssh version. Returns "UNKNOWN" on error.
+func tryGetOpenSSHVersion() string {
+	timeoutCtx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	defer cancel()
+
+	buffer := bytes.NewBuffer([]byte{})
+
+	cmd := exec.CommandContext(timeoutCtx, "ssh", "-V")
+	// ssh -V outputs to stderr.
+	cmd.Stderr = buffer
+
+	if err := cmd.Run(); err != nil {
+		return "UNKNOWN"
+	}
+
+	// ssh -V adds \n to the end of the output.
+	return strings.Replace(buffer.String(), "\n", "", 1)
 }
 
 func main() {
@@ -44,16 +81,6 @@ func main() {
 
 	sshConfig.Args = os.Args[1:]
 
-	if inLegacyMode() {
-		sshConfig.LegacyMode = true
-		err := runLegacyMode(sshConfig)
-		if err != nil {
-			fmt.Printf("error: %s", err)
-			os.Exit(1)
-		}
-		return
-	}
-
 	usageFn, err := parseFlags(mf.RegisterFlags, sshConfig.RegisterFlags, pdcClientCfg.RegisterFlags)
 	if err != nil {
 		fmt.Println("cannot parse flags")
@@ -62,8 +89,27 @@ func main() {
 
 	logger := setupLogger(mf.LogLevel)
 
+	level.Info(logger).Log("msg", "PDC agent info",
+		"version", fmt.Sprintf("v%s", version),
+		"commit", commit,
+		"date", date,
+		"ssh version", tryGetOpenSSHVersion(),
+		"os", runtime.GOOS,
+		"arch", runtime.GOARCH,
+	)
+
 	if mf.PrintHelp {
 		usageFn()
+		return
+	}
+
+	if inLegacyMode() {
+		sshConfig.LegacyMode = true
+		err = runLegacyMode(sshConfig)
+		if err != nil {
+			fmt.Printf("error: %s", err)
+			os.Exit(1)
+		}
 		return
 	}
 


### PR DESCRIPTION
On startup: log the agent version, ssh version and os/arch.

```
level=info caller=main.go:91 msg="PDC agent info" version=v2.0.0 commit=<hash> date=<date> sshversion="OpenSSH_9.4p1, LibreSSL 3.3.6" os=darwin arch=arm64
level=info caller=ssh.go:106 msg="starting ssh client"
level=info caller=keymanager.go:53 msg="starting key manager"
...
```

Not including the ssh flags because they can be anything

Closes https://github.com/grafana/pdc-agent/issues/35