### PR TITLE
deprecate -log-level=<int> / map -log.level=<string> to a ssh log level

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,17 @@ The Grafana Private Datasource Connect Agent allows connecting private datasourc
 
 Follow installation and running instructions in the [Grafana Labs Documentation](https://grafana.com/docs/grafana-cloud/data-configuration/configure-private-datasource-connect/)
 
+## Setting the ssh log level
+
+Use the `-log.level` flag. Run the agent with the `-help` flag to see the possible values.
+
+| go log level | ssh log level    |
+| ------------ | ---------------- |
+| `error`      | 0 (`-v` not set) |
+| `warn`       | 0 (`-v` not set) |
+| `info`       | 0 (`-v` not set) |
+| `debug`      | 3 (`-vvv`)       |
+
 ## DEV flags
 
 Flags prefixed with `-dev` are used for local development and can be removed at any time.

--- a/cmd/pdc/main_test.go
+++ b/cmd/pdc/main_test.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLogLevelToSSHLogLevel(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		description   string
+		level         string
+		expectedLevel int
+		expectedErr   error
+	}{
+		{
+			description:   "error becomes 0",
+			level:         "error",
+			expectedLevel: 0,
+		},
+		{
+			description:   "warn becomes 0",
+			level:         "warn",
+			expectedLevel: 0,
+		},
+		{
+			description:   "info becomes 0",
+			level:         "info",
+			expectedLevel: 0,
+		},
+		{
+			description:   "debug becomes 3",
+			level:         "debug",
+			expectedLevel: 3,
+		},
+		{
+			description: "unknown level, should return error",
+			level:       "unknown",
+			expectedErr: errors.New("invalid log level: unknown"),
+		},
+	}
+
+	for _, tt := range cases {
+		tt := tt
+		t.Run(tt.description, func(t *testing.T) {
+			t.Parallel()
+
+			actual, err := logLevelToSSHLogLevel(tt.level)
+
+			if tt.expectedErr != nil {
+				assert.Equal(t, tt.expectedErr, err)
+			} else {
+				assert.Equal(t, tt.expectedLevel, actual)
+			}
+		})
+	}
+}

--- a/pkg/ssh/ssh.go
+++ b/pkg/ssh/ssh.go
@@ -57,11 +57,13 @@ func DefaultConfig() *Config {
 }
 
 func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
+	var deprecatedInt int
+
 	def := DefaultConfig()
 
 	cfg.SSHFlags = []string{}
 	f.StringVar(&cfg.KeyFile, "ssh-key-file", def.KeyFile, "The path to the SSH key file.")
-	f.IntVar(&cfg.LogLevel, "log-level", def.LogLevel, "The level of log verbosity. The maximum is 3.")
+	f.IntVar(&deprecatedInt, "log-level", def.LogLevel, "The level of log verbosity. The maximum is 3.")
 	// use default log level if invalid
 	if cfg.LogLevel > 3 {
 		cfg.LogLevel = def.LogLevel

--- a/pkg/ssh/ssh.go
+++ b/pkg/ssh/ssh.go
@@ -63,7 +63,7 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 
 	cfg.SSHFlags = []string{}
 	f.StringVar(&cfg.KeyFile, "ssh-key-file", def.KeyFile, "The path to the SSH key file.")
-	f.IntVar(&deprecatedInt, "log-level", def.LogLevel, "The level of log verbosity. The maximum is 3.")
+	f.IntVar(&deprecatedInt, "log-level", def.LogLevel, "[DEPRECATED] The level of log verbosity. The maximum is 3.")
 	// use default log level if invalid
 	if cfg.LogLevel > 3 {
 		cfg.LogLevel = def.LogLevel

--- a/pkg/ssh/ssh.go
+++ b/pkg/ssh/ssh.go
@@ -64,7 +64,7 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 
 	cfg.SSHFlags = []string{}
 	f.StringVar(&cfg.KeyFile, "ssh-key-file", def.KeyFile, "The path to the SSH key file.")
-	f.IntVar(&deprecatedInt, "log-level", def.LogLevel, "[DEPRECATED] The level of log verbosity. The maximum is 3.")
+	f.IntVar(&deprecatedInt, "log-level", def.LogLevel, "[DEPRECATED] Use the log.level flag. The level of log verbosity. The maximum is 3.")
 	// use default log level if invalid
 	if cfg.LogLevel > 3 {
 		cfg.LogLevel = def.LogLevel


### PR DESCRIPTION
- Deprecates `-log-level=<int>`
- Maps `-log.level=<string>` to a ssh log level

The mapping was taken from the issue:
go log level | ssh log level
--- | ---
`error` | 0 (`-v` not set)
`warn` | 0 (`-v` not set)
`info` | 0 (`-v` not set)
`debug` | 3 (`-vvv`)

Closes https://github.com/grafana/pdc-agent/issues/51