### PR TITLE
add agent version to user agent header

### DIFF
--- a/cmd/pdc/main.go
+++ b/cmd/pdc/main.go
@@ -136,6 +136,7 @@ func main() {
 		os.Exit(1)
 	}
 
+	pdcClientCfg.Version = version
 	pdcClientCfg.URL = apiURL
 	sshConfig.PDC = *pdcClientCfg
 	sshConfig.URL = gatewayURL

--- a/pkg/httpclient/transport.go
+++ b/pkg/httpclient/transport.go
@@ -8,12 +8,12 @@ import (
 
 // UserAgentTransport provides a transport with a set user-agent. It wraps
 // http.DefaultTransport if rt is nil
-func UserAgentTransport(rt http.RoundTripper) http.RoundTripper {
+func UserAgentTransport(rt http.RoundTripper, version string) http.RoundTripper {
 	if rt == nil {
 		rt = http.DefaultTransport
 	}
 
-	ua := "pdc-httpclient pdc-agent"
+	ua := "pdc-httpclient pdc-agent " + version
 	tr := promhttp.RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
 		if req.UserAgent() == "" {
 			req.Header.Set("User-Agent", ua)

--- a/pkg/pdc/client.go
+++ b/pkg/pdc/client.go
@@ -36,6 +36,9 @@ type Config struct {
 	URL             *url.URL
 	RetryMax        int
 
+	// The version of pdc-agent thats running, defined by goreleaser during the build process.
+	Version string
+
 	// The PDC api endpoint used to sign public keys.
 	// It is not a constant only to make it easier to override the endpoint in local development.
 	SignPublicKeyEndpoint string
@@ -123,7 +126,7 @@ func NewClient(cfg *Config, logger log.Logger) (Client, error) {
 	rc.CheckRetry = retryablehttp.ErrorPropagatedRetryPolicy
 	hc := rc.StandardClient()
 
-	hc.Transport = httpclient.UserAgentTransport(hc.Transport)
+	hc.Transport = httpclient.UserAgentTransport(hc.Transport, cfg.Version)
 
 	return &pdcClient{
 		cfg:        cfg,


### PR DESCRIPTION
This PR adds the version we get from the goreleaser build to the user agent header we pass to the PDC API. This will give us some loose information on what versions of the pdc-agent people are running in the wild (versions later than the one including this PR, at least!)