### PR TITLE
allow configuring the dev host

### DIFF
--- a/cmd/pdc/main.go
+++ b/cmd/pdc/main.go
@@ -142,7 +142,7 @@ func main() {
 	sshConfig.URL = gatewayURL
 
 	if mf.DevMode {
-		if err := setDevelopmentConfig(sshConfig, pdcClientCfg); err != nil {
+		if err = setDevelopmentConfig(sshConfig, pdcClientCfg); err != nil {
 			level.Error(logger).Log("msg", "error setting development config", "error", err)
 			os.Exit(1)
 		}

--- a/pkg/pdc/client.go
+++ b/pkg/pdc/client.go
@@ -50,6 +50,10 @@ type Config struct {
 	// Used for local development.
 	// DevNetwork is the network that the agent will connect to.
 	DevNetwork string
+
+	// Used for local development.
+	// DevHost is the host that the agent will connect to.
+	DevHost string
 }
 
 func (cfg *Config) RegisterFlags(fs *flag.FlagSet) {
@@ -57,6 +61,7 @@ func (cfg *Config) RegisterFlags(fs *flag.FlagSet) {
 	fs.StringVar(&cfg.Token, "token", "", "The token to use to authenticate with Grafana Cloud. It must have the pdc-signing:write scope")
 	fs.StringVar(&cfg.HostedGrafanaID, "gcloud-hosted-grafana-id", "", "The ID of the Hosted Grafana instance to connect to")
 	fs.StringVar(&cfg.DevNetwork, "dev-network", "", "[DEVELOPMENT ONLY] the network the agent will connect to")
+	fs.StringVar(&cfg.DevHost, "dev-network", "localhost", "[DEVELOPMENT ONLY] the host the agent will connect to")
 	fs.StringVar(&deprecated, "network", "", "DEPRECATED: The name of the PDC network to connect to")
 	fs.IntVar(&cfg.RetryMax, "retrymax", 4, "The max num of retries for http requests")
 }

--- a/pkg/pdc/client.go
+++ b/pkg/pdc/client.go
@@ -61,7 +61,7 @@ func (cfg *Config) RegisterFlags(fs *flag.FlagSet) {
 	fs.StringVar(&cfg.Token, "token", "", "The token to use to authenticate with Grafana Cloud. It must have the pdc-signing:write scope")
 	fs.StringVar(&cfg.HostedGrafanaID, "gcloud-hosted-grafana-id", "", "The ID of the Hosted Grafana instance to connect to")
 	fs.StringVar(&cfg.DevNetwork, "dev-network", "", "[DEVELOPMENT ONLY] the network the agent will connect to")
-	fs.StringVar(&cfg.DevHost, "dev-network", "localhost", "[DEVELOPMENT ONLY] the host the agent will connect to")
+	fs.StringVar(&cfg.DevHost, "dev-host", "localhost", "[DEVELOPMENT ONLY] the host the agent will connect to")
 	fs.StringVar(&deprecated, "network", "", "DEPRECATED: The name of the PDC network to connect to")
 	fs.IntVar(&cfg.RetryMax, "retrymax", 4, "The max num of retries for http requests")
 }


### PR DESCRIPTION
Allow overriding of `localhost` for dev host, for use cases where we're running in docker-compose 