### PR TITLE
goreleaser: add missing image template

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -46,6 +46,7 @@ dockers:
     dockerfile: ./cmd/pdc/Dockerfile
     image_templates:
       - grafana/{{ .ProjectName }}:latest
+      - grafana/{{ .ProjectName }}:latest-amd64
       - grafana/{{ .ProjectName }}:{{ .Version }}
       - grafana/{{ .ProjectName }}:{{ .Version }}-amd64
     build_flag_templates:


### PR DESCRIPTION
The goreleaser build is failing because of this missing template:

```
failed to publish artifacts: failed to create grafana/pdc-agent:latest: exit status 1: no such manifest: docker.io/grafana/pdc-agent:latest-amd64
```