### PR TITLE
Add http server to expose metrics

### DIFF
--- a/cmd/pdc/main.go
+++ b/cmd/pdc/main.go
@@ -191,7 +191,7 @@ func run(logger log.Logger, sshConfig *ssh.Config, pdcConfig *pdc.Config) error 
 	}
 
 	// If ssh client start successfully, start the metrics server
-	ms := metrics.NewMetricsServer(logger, sshConfig.MetricsHTTPPort)
+	ms := metrics.NewMetricsServer(logger, sshConfig.MetricsAddr)
 	go ms.Run()
 
 	// Wait for the ssh client to exit

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -2,7 +2,6 @@ package metrics
 
 import (
 	"errors"
-	"fmt"
 	"net/http"
 
 	"github.com/go-kit/log"
@@ -29,7 +28,7 @@ func NewMetricsServer(logger log.Logger, addr string) *Server {
 }
 
 func (s *Server) Run() {
-	level.Info(s.logger).Log("msg", "starting serving metrics on port "+s.httpServer.Addr)
+	level.Info(s.logger).Log("msg", "Starting serving metrics", "addr", s.httpServer.Addr)
 	if err := s.httpServer.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
 		level.Info(s.logger).Log("msg", "failed to run metrics server", "err", err)
 	}

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -1,0 +1,36 @@
+package metrics
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+)
+
+type Server struct {
+	httpServer *http.Server
+	logger     log.Logger
+}
+
+func NewMetricsServer(logger log.Logger, port int) *Server {
+	mux := http.NewServeMux()
+	mux.Handle("/metrics", promhttp.Handler())
+
+	return &Server{
+		logger: logger,
+		httpServer: &http.Server{
+			Addr:    fmt.Sprintf(":%d", port),
+			Handler: mux,
+		},
+	}
+}
+
+func (s *Server) Run() {
+	level.Info(s.logger).Log("msg", "starting serving metrics on port "+s.httpServer.Addr)
+	if err := s.httpServer.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+		level.Info(s.logger).Log("msg", "failed to run metrics server", "err", err)
+	}
+}

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -15,14 +15,14 @@ type Server struct {
 	logger     log.Logger
 }
 
-func NewMetricsServer(logger log.Logger, port int) *Server {
+func NewMetricsServer(logger log.Logger, addr string) *Server {
 	mux := http.NewServeMux()
 	mux.Handle("/metrics", promhttp.Handler())
 
 	return &Server{
 		logger: logger,
 		httpServer: &http.Server{
-			Addr:    fmt.Sprintf(":%d", port),
+			Addr:    addr,
 			Handler: mux,
 		},
 	}

--- a/pkg/ssh/ssh.go
+++ b/pkg/ssh/ssh.go
@@ -84,7 +84,7 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	f.BoolVar(&cfg.ForceKeyFileOverwrite, "force-key-file-overwrite", false, "Force a new ssh key pair to be generated")
 	f.DurationVar(&cfg.CertExpiryWindow, "cert-expiry-window", 5*time.Minute, "The time before the certificate expires to renew it.")
 	f.DurationVar(&cfg.CertCheckCertExpiryPeriod, "cert-check-expiry-period", 1*time.Minute, "How often to check certificate validity. 0 means it is only checked at start")
-	f.IntVar(&cfg.MetricsHTTPPort, "metrics-http-port", 8090, "The port to expose metrics on. Default is 8090.")
+	f.StringVar(&cfg.MetricsAddr, "metrics-addr", ":8090", "The port to expose metrics on")
 }
 
 func (cfg Config) KeyFileDir() string {

--- a/pkg/ssh/ssh.go
+++ b/pkg/ssh/ssh.go
@@ -49,7 +49,8 @@ type Config struct {
 	// is valid and regenerate it if necessary.
 	CertCheckCertExpiryPeriod time.Duration
 	URL                       *url.URL
-	MetricsHTTPPort           int
+	// MetricsAddr is the port to expose metrics on
+	MetricsAddr string
 }
 
 // DefaultConfig returns a Config with some sensible defaults set
@@ -84,7 +85,7 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	f.BoolVar(&cfg.ForceKeyFileOverwrite, "force-key-file-overwrite", false, "Force a new ssh key pair to be generated")
 	f.DurationVar(&cfg.CertExpiryWindow, "cert-expiry-window", 5*time.Minute, "The time before the certificate expires to renew it.")
 	f.DurationVar(&cfg.CertCheckCertExpiryPeriod, "cert-check-expiry-period", 1*time.Minute, "How often to check certificate validity. 0 means it is only checked at start")
-	f.StringVar(&cfg.MetricsAddr, "metrics-addr", ":8090", "The port to expose metrics on")
+	f.StringVar(&cfg.MetricsAddr, "metrics-addr", ":8090", "HTTP server address to expose metrics on")
 }
 
 func (cfg Config) KeyFileDir() string {

--- a/pkg/ssh/ssh.go
+++ b/pkg/ssh/ssh.go
@@ -49,6 +49,7 @@ type Config struct {
 	// is valid and regenerate it if necessary.
 	CertCheckCertExpiryPeriod time.Duration
 	URL                       *url.URL
+	MetricsHTTPPort           int
 }
 
 // DefaultConfig returns a Config with some sensible defaults set
@@ -83,7 +84,7 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	f.BoolVar(&cfg.ForceKeyFileOverwrite, "force-key-file-overwrite", false, "Force a new ssh key pair to be generated")
 	f.DurationVar(&cfg.CertExpiryWindow, "cert-expiry-window", 5*time.Minute, "The time before the certificate expires to renew it.")
 	f.DurationVar(&cfg.CertCheckCertExpiryPeriod, "cert-check-expiry-period", 1*time.Minute, "How often to check certificate validity. 0 means it is only checked at start")
-
+	f.IntVar(&cfg.MetricsHTTPPort, "metrics-http-port", 8090, "The port to expose metrics on. Default is 8090.")
 }
 
 func (cfg Config) KeyFileDir() string {


### PR DESCRIPTION
Contributes to https://github.com/grafana/pdc-agent/issues/41
Thus far the endpoint only server default metrics provided by instrumentation package.