### PR TITLE
Add simple makefile 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,4 +23,6 @@ main
 .vscode/
 !.vscode/launch.json
 
-pdc
+# ignore build artifacts
+/pdc-agent
+/pdc

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 BINARY_NAME=pdc-agent
-.PHONY: all build test lint clean
+
 all: lint build test
 
 build:
@@ -14,3 +14,5 @@ lint:
 clean:
 	go clean
 	rm ${BINARY_NAME}
+
+.PHONY: all build test lint clean

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,16 @@
+BINARY_NAME=pdc-agent
+
+all: lint build test
+
+build:
+	go build -o ${BINARY_NAME} ./cmd/pdc/
+
+test:
+	go test -timeout=5m -race -coverprofile=c.out ./...
+
+lint:
+	golangci-lint run --max-same-issues=0 --max-issues-per-linter=0
+
+clean:
+	go clean
+	rm ${BINARY_NAME}

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 BINARY_NAME=pdc-agent
-
+.PHONY: all build test lint clean
 all: lint build test
 
 build:

--- a/README.md
+++ b/README.md
@@ -21,6 +21,27 @@ Use the `-log.level` flag. Run the agent with the `-help` flag to see the possib
 
 Flags prefixed with `-dev` are used for local development and can be removed at any time.
 
+# Developer guide
+
+## Dependencies
+
+You will need the following dependencies to test and build the pdc-agent:
+
+- git
+- go (see [`go.mod`](./go.mod) for minimum required version)
+- [golangci-lint](https://golangci-lint.run/)
+- [gh](https://cli.github.com/), the GitHub cli (for releasing only)
+
+
+## Build and test
+
+Run unit tests, lint and build with:
+
+```
+make
+```
+
+
 ## Releasing
 
 Create public releases with `gh release create vX.X.X --generate-notes`
@@ -36,7 +57,3 @@ If you want the docker image locally, you can run
 ```
 goreleaser release --snapshot --clean
 ```
-
-## Building
-
-`CGO_ENABLED=0 go build ./cmd/pdc`


### PR DESCRIPTION
This PR adds a simple Makefile to the repo with targets for build, lint and run. I've also updated the README to prompt contributors to use the makefile when developing locally. 
