### PR TITLE
make domain and ports configurable in dev mode

### DIFF
--- a/cmd/pdc/main.go
+++ b/cmd/pdc/main.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"net"
 	"net/url"
 	"os"
 	"os/exec"
@@ -157,7 +158,7 @@ func main() {
 
 // Configures the agent for local development
 func setDevelopmentConfig(domain string, sshCfg *ssh.Config, pdcClientCfg *pdc.Config) {
-	pdcClientCfg.URL, _ = url.Parse(fmt.Sprintf("http://%s:%d", domain, pdcClientCfg.DevPort))
+	pdcClientCfg.URL, _ = url.Parse(net.JoinHostPort(domain, pdcClientCfg.DevPort))
 
 	pdcClientCfg.DevHeaders = map[string]string{
 		"X-Scope-OrgID":      pdcClientCfg.HostedGrafanaID,

--- a/pkg/pdc/client.go
+++ b/pkg/pdc/client.go
@@ -50,15 +50,21 @@ type Config struct {
 	// Used for local development.
 	// DevNetwork is the network that the agent will connect to.
 	DevNetwork string
+
+	// Used for local development.
+	// DevPort is the port number for the PDC API
+	DevPort int
 }
 
 func (cfg *Config) RegisterFlags(fs *flag.FlagSet) {
 	var deprecated string
 	fs.StringVar(&cfg.Token, "token", "", "The token to use to authenticate with Grafana Cloud. It must have the pdc-signing:write scope")
 	fs.StringVar(&cfg.HostedGrafanaID, "gcloud-hosted-grafana-id", "", "The ID of the Hosted Grafana instance to connect to")
-	fs.StringVar(&cfg.DevNetwork, "dev-network", "", "[DEVELOPMENT ONLY] the network the agent will connect to")
 	fs.StringVar(&deprecated, "network", "", "DEPRECATED: The name of the PDC network to connect to")
 	fs.IntVar(&cfg.RetryMax, "retrymax", 4, "The max num of retries for http requests")
+
+	fs.StringVar(&cfg.DevNetwork, "dev-network", "", "[DEVELOPMENT ONLY] the network the agent will connect to")
+	fs.IntVar(&cfg.DevPort, "dev-api-port", 9181, "[DEVELOPMENT ONLY] The port to use for agent connections to the PDC API")
 }
 
 // Client is a PDC API client

--- a/pkg/pdc/client.go
+++ b/pkg/pdc/client.go
@@ -53,7 +53,7 @@ type Config struct {
 
 	// Used for local development.
 	// DevPort is the port number for the PDC API
-	DevPort int
+	DevPort string
 }
 
 func (cfg *Config) RegisterFlags(fs *flag.FlagSet) {
@@ -64,7 +64,7 @@ func (cfg *Config) RegisterFlags(fs *flag.FlagSet) {
 	fs.IntVar(&cfg.RetryMax, "retrymax", 4, "The max num of retries for http requests")
 
 	fs.StringVar(&cfg.DevNetwork, "dev-network", "", "[DEVELOPMENT ONLY] the network the agent will connect to")
-	fs.IntVar(&cfg.DevPort, "dev-api-port", 9181, "[DEVELOPMENT ONLY] The port to use for agent connections to the PDC API")
+	fs.StringVar(&cfg.DevPort, "dev-api-port", "9181", "[DEVELOPMENT ONLY] The port to use for agent connections to the PDC API")
 }
 
 // Client is a PDC API client

--- a/pkg/ssh/ssh.go
+++ b/pkg/ssh/ssh.go
@@ -51,6 +51,10 @@ type Config struct {
 	URL                       *url.URL
 	// MetricsAddr is the port to expose metrics on
 	MetricsAddr string
+
+	// Used for local development.
+	// DevPort is the port number for the PDC gateway
+	DevPort int
 }
 
 // DefaultConfig returns a Config with some sensible defaults set
@@ -86,6 +90,9 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	f.DurationVar(&cfg.CertExpiryWindow, "cert-expiry-window", 5*time.Minute, "The time before the certificate expires to renew it.")
 	f.DurationVar(&cfg.CertCheckCertExpiryPeriod, "cert-check-expiry-period", 1*time.Minute, "How often to check certificate validity. 0 means it is only checked at start")
 	f.StringVar(&cfg.MetricsAddr, "metrics-addr", ":8090", "HTTP server address to expose metrics on")
+
+	f.IntVar(&cfg.DevPort, "dev-ssh-port", 2244, "[DEVELOPMENT ONLY] The port to use for agent connections to the PDC SSH gateway")
+
 }
 
 func (cfg Config) KeyFileDir() string {


### PR DESCRIPTION
When dev-mode is enabled, this PR will allow:

- set the domain with `-domain` (including hostname)
- set the API port
- set the SSH port

This makes some hard-coded values more configurable, but is required to be able to run pdc-agent in a local k8s setup.