### PR TITLE
Add protocol to domain when running in dev mode

### DIFF
--- a/cmd/pdc/main.go
+++ b/cmd/pdc/main.go
@@ -158,7 +158,7 @@ func main() {
 
 // Configures the agent for local development
 func setDevelopmentConfig(domain string, sshCfg *ssh.Config, pdcClientCfg *pdc.Config) {
-	pdcClientCfg.URL, _ = url.Parse(net.JoinHostPort(domain, pdcClientCfg.DevPort))
+	pdcClientCfg.URL, _ = url.Parse("http://" + net.JoinHostPort(domain, pdcClientCfg.DevPort))
 
 	pdcClientCfg.DevHeaders = map[string]string{
 		"X-Scope-OrgID":      pdcClientCfg.HostedGrafanaID,


### PR DESCRIPTION
Add protocol for convenience when using the domain in dev mode. Followup to https://github.com/grafana/pdc-agent/pull/108. Domain shouldn't have to contain the protocol.