### PR TITLE
Disable TCPKeepAlive by default

### DIFF
--- a/pkg/ssh/ssh.go
+++ b/pkg/ssh/ssh.go
@@ -235,12 +235,13 @@ func (s *Client) SSHFlagsFromConfig() ([]string, error) {
 	gwURL := s.cfg.URL
 	user := fmt.Sprintf("%s@%s", s.cfg.PDC.HostedGrafanaID, gwURL.String())
 
-	// keep ssh_config parameters in a map so they can be oveeridden by the user
+	// keep ssh_config parameters in a map so they can be overidden by the user
 	sshOptions := map[string]string{
 		"UserKnownHostsFile":  fmt.Sprintf("%s/%s", keyFileDir, KnownHostsFile),
 		"CertificateFile":     fmt.Sprintf("%s-cert.pub", s.cfg.KeyFile),
 		"ServerAliveInterval": "15",
 		"ConnectTimeout":      "1",
+		"TCPKeepAlive":        "no",
 	}
 
 	nonOptionFlags := []string{} // for backwards compatibility, on -v particularly

--- a/pkg/ssh/ssh_test.go
+++ b/pkg/ssh/ssh_test.go
@@ -146,7 +146,7 @@ func TestClient_SSHArgs(t *testing.T) {
 		result, err := sshClient.SSHFlagsFromConfig()
 
 		assert.Nil(t, err)
-		assert.Equal(t, strings.Split(fmt.Sprintf("-i %s 123@host.grafana.net -p 22 -R 0 -o CertificateFile=%s -o ConnectTimeout=1 -o ServerAliveInterval=15 -o UserKnownHostsFile=%s -vv", cfg.KeyFile, cfg.KeyFile+certSuffix, path.Join(cfg.KeyFileDir(), ssh.KnownHostsFile)), " "), result)
+		assert.Equal(t, strings.Split(fmt.Sprintf("-i %s 123@host.grafana.net -p 22 -R 0 -o CertificateFile=%s -o ConnectTimeout=1 -o ServerAliveInterval=15 -o TCPKeepAlive=no -o UserKnownHostsFile=%s -vv", cfg.KeyFile, cfg.KeyFile+certSuffix, path.Join(cfg.KeyFileDir(), ssh.KnownHostsFile)), " "), result)
 	})
 
 	t.Run("legacy args (deprecated)", func(t *testing.T) {
@@ -195,6 +195,7 @@ func TestClient_SSHArgs(t *testing.T) {
 			"-o", "ConnectTimeout=3",
 			"-o", "PermitRemoteOpen=host:123 host:456",
 			"-o", "ServerAliveInterval=15",
+			"-o", "TCPKeepAlive=no",
 			"-o", "TestOption=2",
 			"-o", fmt.Sprintf("UserKnownHostsFile=%s", path.Join(cfg.KeyFileDir(), ssh.KnownHostsFile)),
 			"-vv",
@@ -223,6 +224,7 @@ func TestClient_SSHArgs(t *testing.T) {
 			"-o", fmt.Sprintf("CertificateFile=%s", cfg.KeyFile+certSuffix),
 			"-o", "ConnectTimeout=1",
 			"-o", "ServerAliveInterval=15",
+			"-o", "TCPKeepAlive=no",
 			"-o", fmt.Sprintf("UserKnownHostsFile=%s", path.Join(cfg.KeyFileDir(), ssh.KnownHostsFile)),
 		}
 		assert.Equal(t, expected, result)
@@ -244,6 +246,7 @@ func TestClient_SSHArgs(t *testing.T) {
 			"-o", fmt.Sprintf("CertificateFile=%s", cfg.KeyFile+certSuffix),
 			"-o", "ConnectTimeout=1",
 			"-o", "ServerAliveInterval=15",
+			"-o", "TCPKeepAlive=no",
 			"-o", fmt.Sprintf("UserKnownHostsFile=%s", path.Join(cfg.KeyFileDir(), ssh.KnownHostsFile)),
 			"-vv",
 		}


### PR DESCRIPTION
Closes https://github.com/grafana/hosted-grafana/issues/5795


We've found through debugging customer issues that the TCPKeepAlive ssh_config option, which is enabled by default, causes the agent to disconnect more often than needed. The TCP keepalive is somewhat redundant because we have the ServerKeepAlive running. The TCP keepalive behaviour is also variable depending on the environment its running in, and it has a poor feedback mechanism.

This PR sets the `TCPKeepAlive` option to `no` by default. This can be overridden by the user using `--ssh-flag` if they wish.