### PR TITLE
Parse metrics from logs

### DIFF
--- a/pkg/metrics/utils.go
+++ b/pkg/metrics/utils.go
@@ -6,7 +6,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
-func NewNativeHistogramVec(opts prometheus.HistogramOpts, labelNames []string) *prometheus.HistogramVec {
+func NativeHistogramOpts(opts prometheus.HistogramOpts) prometheus.HistogramOpts {
 	if opts.NativeHistogramBucketFactor == 0 {
 		// Enable native histograms, with the factor suggested in the docs
 		opts.NativeHistogramBucketFactor = 1.1
@@ -21,5 +21,5 @@ func NewNativeHistogramVec(opts prometheus.HistogramOpts, labelNames []string) *
 		opts.NativeHistogramMinResetDuration = 1 * time.Hour
 	}
 
-	return prometheus.NewHistogramVec(opts, labelNames)
+	return opts
 }

--- a/pkg/metrics/utils.go
+++ b/pkg/metrics/utils.go
@@ -6,7 +6,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
-func NativeHistogramOpts(opts prometheus.HistogramOpts) prometheus.HistogramOpts {
+func nativeHistogramOpts(opts prometheus.HistogramOpts) prometheus.HistogramOpts {
 	if opts.NativeHistogramBucketFactor == 0 {
 		// Enable native histograms, with the factor suggested in the docs
 		opts.NativeHistogramBucketFactor = 1.1
@@ -22,4 +22,12 @@ func NativeHistogramOpts(opts prometheus.HistogramOpts) prometheus.HistogramOpts
 	}
 
 	return opts
+}
+
+func NewNativeHistogramVec(opts prometheus.HistogramOpts, labelNames []string) *prometheus.HistogramVec {
+	return prometheus.NewHistogramVec(nativeHistogramOpts(opts), labelNames)
+}
+
+func NewNativeHistogram(opts prometheus.HistogramOpts) prometheus.Histogram {
+	return prometheus.NewHistogram(nativeHistogramOpts(opts))
 }

--- a/pkg/pdc/metrics.go
+++ b/pkg/pdc/metrics.go
@@ -11,12 +11,13 @@ type promMetrics struct {
 
 func newPromMetrics() *promMetrics {
 	return &promMetrics{
-		signingRequests: metrics.NewNativeHistogramVec(
-			prometheus.HistogramOpts{
-				Name:      "signing_requests_duration_seconds",
-				Help:      "Duration of signing requests in seconds",
-				Namespace: "pdc_agent",
-			},
+		signingRequests: prometheus.NewHistogramVec(
+			metrics.NativeHistogramOpts(
+				prometheus.HistogramOpts{
+					Name:      "signing_requests_duration_seconds",
+					Help:      "Duration of signing requests in seconds",
+					Namespace: "pdc_agent",
+				}),
 			[]string{"status"},
 		),
 	}

--- a/pkg/pdc/metrics.go
+++ b/pkg/pdc/metrics.go
@@ -11,13 +11,12 @@ type promMetrics struct {
 
 func newPromMetrics() *promMetrics {
 	return &promMetrics{
-		signingRequests: prometheus.NewHistogramVec(
-			metrics.NativeHistogramOpts(
-				prometheus.HistogramOpts{
-					Name:      "signing_requests_duration_seconds",
-					Help:      "Duration of signing requests in seconds",
-					Namespace: "pdc_agent",
-				}),
+		signingRequests: metrics.NewNativeHistogramVec(
+			prometheus.HistogramOpts{
+				Name:      "signing_requests_duration_seconds",
+				Help:      "Duration of signing requests in seconds",
+				Namespace: "pdc_agent",
+			},
 			[]string{"status"},
 		),
 	}

--- a/pkg/ssh/metrics.go
+++ b/pkg/ssh/metrics.go
@@ -13,7 +13,7 @@ import (
 
 var (
 	reConnSuccess   = regexp.MustCompile(`connected to (.+?) port (\d+)`)
-	reConnFailure   = regexp.MustCompile(`connect_to (.+?) port (\d+): failed.`)
+	reConnFailure   = regexp.MustCompile(`connect_to (.+?)(?: port (\d+))?:`)
 	reChannelsCount = regexp.MustCompile(`nchannels (\d+)`)
 )
 

--- a/pkg/ssh/metrics.go
+++ b/pkg/ssh/metrics.go
@@ -21,7 +21,7 @@ type promMetrics struct {
 	sshRestartsCount    *prometheus.CounterVec
 	tcpConnectionsCount *prometheus.CounterVec
 	timeToConnect       prometheus.Histogram
-	channelsCount       prometheus.Gauge
+	openChannelsCount   prometheus.Gauge
 }
 
 func newPromMetrics() *promMetrics {
@@ -34,10 +34,10 @@ func newPromMetrics() *promMetrics {
 			},
 			[]string{"exit_code"},
 		),
-		channelsCount: prometheus.NewGauge(
+		openChannelsCount: prometheus.NewGauge(
 			prometheus.GaugeOpts{
-				Name:      "ssh_channels",
-				Help:      "Number of active SSH channels",
+				Name:      "ssh_open_channels",
+				Help:      "Number of open SSH channels",
 				Namespace: "pdc_agent",
 			},
 		),
@@ -80,7 +80,7 @@ func (p logMetricsParser) channelsCount(msg []byte) {
 	matches := reChannelsCount.FindSubmatch(msg)
 	if len(matches) > 1 {
 		if value, err := strconv.Atoi(string(matches[1])); err == nil {
-			p.m.channelsCount.Set(float64(value))
+			p.m.openChannelsCount.Set(float64(value))
 		}
 	}
 }

--- a/pkg/ssh/metrics.go
+++ b/pkg/ssh/metrics.go
@@ -49,13 +49,12 @@ func newPromMetrics() *promMetrics {
 			},
 			[]string{"target", "status"},
 		),
-		timeToConnect: prometheus.NewHistogram(
-			metrics.NativeHistogramOpts(
-				prometheus.HistogramOpts{
-					Name:      "ssh_time_to_connect_seconds",
-					Help:      "Time spent to establish SSH connection",
-					Namespace: "pdc_agent",
-				})),
+		timeToConnect: metrics.NewNativeHistogram(
+			prometheus.HistogramOpts{
+				Name:      "ssh_time_to_connect_seconds",
+				Help:      "Time spent to establish SSH connection",
+				Namespace: "pdc_agent",
+			}),
 	}
 }
 

--- a/pkg/ssh/metrics.go
+++ b/pkg/ssh/metrics.go
@@ -49,16 +49,19 @@ type logMetricsParser struct {
 func (p logMetricsParser) parseLogMetrics(msg []byte) {
 	if bytes.Contains(msg, []byte("nchannels")) {
 		p.channelsCount(msg)
+		return
 	}
 
 	if bytes.Contains(msg, []byte("connected to")) {
 		pattern := `connected to (.+?) port (\d+)`
 		p.tcpConnCount(msg, pattern, "success")
+		return
 	}
 
 	if bytes.Contains(msg, []byte("connect_to")) {
 		pattern := `connect_to (.+?) port (\d+): failed.`
 		p.tcpConnCount(msg, pattern, "failure")
+		return
 	}
 }
 

--- a/pkg/ssh/metrics.go
+++ b/pkg/ssh/metrics.go
@@ -1,9 +1,17 @@
 package ssh
 
-import "github.com/prometheus/client_golang/prometheus"
+import (
+	"bytes"
+	"regexp"
+	"strconv"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
 
 type promMetrics struct {
-	sshRestartsCount *prometheus.CounterVec
+	sshRestartsCount    *prometheus.CounterVec
+	tcpConnectionsCount *prometheus.GaugeVec
+	channelsCount       prometheus.Gauge
 }
 
 func newPromMetrics() *promMetrics {
@@ -16,5 +24,63 @@ func newPromMetrics() *promMetrics {
 			},
 			[]string{"exit_code"},
 		),
+		channelsCount: prometheus.NewGauge(
+			prometheus.GaugeOpts{
+				Name:      "ssh_channels",
+				Help:      "Number of active SSH channels",
+				Namespace: "pdc_agent",
+			},
+		),
+		tcpConnectionsCount: prometheus.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Name:      "tcp_connections",
+				Help:      "Number of open TCP connections",
+				Namespace: "pdc_agent",
+			},
+			[]string{"target", "status"},
+		),
+	}
+}
+
+type logMetricsParser struct {
+	m *promMetrics
+}
+
+func (p logMetricsParser) parseLogMetrics(msg []byte) {
+	if bytes.Contains(msg, []byte("nchannels")) {
+		p.channelsCount(msg)
+	}
+
+	if bytes.Contains(msg, []byte("connected to")) {
+		pattern := `connected to (.+?) port (\d+)`
+		p.tcpConnCount(msg, pattern, "success")
+	}
+
+	if bytes.Contains(msg, []byte("connect_to")) {
+		pattern := `connect_to (.+?) port (\d+): failed.`
+		p.tcpConnCount(msg, pattern, "failure")
+	}
+}
+
+func (p logMetricsParser) channelsCount(msg []byte) {
+	re := regexp.MustCompile(`nchannels (\d+)`)
+	matches := re.FindSubmatch(msg)
+	if len(matches) > 1 {
+		if value, err := strconv.Atoi(string(matches[1])); err == nil {
+			p.m.channelsCount.Set(float64(value))
+		}
+	}
+}
+
+func (p logMetricsParser) tcpConnCount(msg []byte, pattern string, status string) {
+	re := regexp.MustCompile(pattern)
+	matches := re.FindSubmatch(msg)
+	if len(matches) > 1 {
+		// target host name, and port if specified
+		target := string(matches[1])
+		if len(matches) > 2 && len(matches[2]) > 0 {
+			target += ":" + string(matches[2])
+		}
+		p.m.tcpConnectionsCount.WithLabelValues(target, status).Add(1)
 	}
 }

--- a/pkg/ssh/ssh.go
+++ b/pkg/ssh/ssh.go
@@ -172,6 +172,7 @@ func (s *Client) starting(ctx context.Context) error {
 		cmd := exec.CommandContext(ctx, s.SSHCmd, flags...)
 
 		var mParser *logMetricsParser
+		level.Debug(s.logger).Log("msg", "parsing metrics from logs", "enabled", s.cfg.ParseMetrics)
 		if s.cfg.ParseMetrics {
 			mParser = &logMetricsParser{m: s.metrics}
 		}

--- a/pkg/ssh/ssh.go
+++ b/pkg/ssh/ssh.go
@@ -129,7 +129,7 @@ func NewClient(cfg *Config, logger log.Logger, km *KeyManager) *Client {
 
 func (s *Client) Collect(ch chan<- prometheus.Metric) {
 	s.metrics.sshRestartsCount.Collect(ch)
-	s.metrics.channelsCount.Collect(ch)
+	s.metrics.openChannelsCount.Collect(ch)
 	s.metrics.tcpConnectionsCount.Collect(ch)
 	s.metrics.timeToConnect.Collect(ch)
 
@@ -137,7 +137,7 @@ func (s *Client) Collect(ch chan<- prometheus.Metric) {
 
 func (s *Client) Describe(ch chan<- *prometheus.Desc) {
 	s.metrics.sshRestartsCount.Describe(ch)
-	s.metrics.channelsCount.Describe(ch)
+	s.metrics.openChannelsCount.Describe(ch)
 	s.metrics.tcpConnectionsCount.Describe(ch)
 	s.metrics.timeToConnect.Describe(ch)
 }

--- a/pkg/ssh/ssh.go
+++ b/pkg/ssh/ssh.go
@@ -50,8 +50,10 @@ type Config struct {
 	// is valid and regenerate it if necessary.
 	CertCheckCertExpiryPeriod time.Duration
 	URL                       *url.URL
+
 	// MetricsAddr is the port to expose metrics on
-	MetricsAddr string
+	MetricsAddr  string
+	ParseMetrics bool
 
 	// Used for local development.
 	// DevPort is the port number for the PDC gateway
@@ -66,10 +68,11 @@ func DefaultConfig() *Config {
 		root = ""
 	}
 	return &Config{
-		Port:     22,
-		PDC:      pdc.Config{},
-		LogLevel: "info",
-		KeyFile:  path.Join(root, ".ssh/grafana_pdc"),
+		Port:         22,
+		PDC:          pdc.Config{},
+		LogLevel:     "info",
+		KeyFile:      path.Join(root, ".ssh/grafana_pdc"),
+		ParseMetrics: true,
 	}
 }
 
@@ -84,6 +87,7 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	f.DurationVar(&cfg.CertExpiryWindow, "cert-expiry-window", 5*time.Minute, "The time before the certificate expires to renew it.")
 	f.DurationVar(&cfg.CertCheckCertExpiryPeriod, "cert-check-expiry-period", 1*time.Minute, "How often to check certificate validity. 0 means it is only checked at start")
 	f.StringVar(&cfg.MetricsAddr, "metrics-addr", ":8090", "HTTP server address to expose metrics on")
+	f.BoolVar(&cfg.ParseMetrics, "parse-metrics", true, "Enabled or disable parsing of metrics from the ssh logs")
 
 	f.IntVar(&cfg.DevPort, "dev-ssh-port", 2244, "[DEVELOPMENT ONLY] The port to use for agent connections to the PDC SSH gateway")
 
@@ -125,10 +129,14 @@ func NewClient(cfg *Config, logger log.Logger, km *KeyManager) *Client {
 
 func (s *Client) Collect(ch chan<- prometheus.Metric) {
 	s.metrics.sshRestartsCount.Collect(ch)
+	s.metrics.channelsCount.Collect(ch)
+	s.metrics.tcpConnectionsCount.Collect(ch)
 }
 
 func (s *Client) Describe(ch chan<- *prometheus.Desc) {
 	s.metrics.sshRestartsCount.Describe(ch)
+	s.metrics.channelsCount.Describe(ch)
+	s.metrics.tcpConnectionsCount.Describe(ch)
 }
 
 func (s *Client) starting(ctx context.Context) error {
@@ -162,9 +170,15 @@ func (s *Client) starting(ctx context.Context) error {
 	retryOpts := retry.Opts{MaxBackoff: 16 * time.Second, InitialBackoff: 1 * time.Second}
 	go retry.Forever(retryOpts, func() error {
 		cmd := exec.CommandContext(ctx, s.SSHCmd, flags...)
-		loggerWriter := newLoggerWriterAdapter(s.logger, s.cfg.LogLevel)
+
+		var mParser *logMetricsParser
+		if s.cfg.ParseMetrics {
+			mParser = &logMetricsParser{m: s.metrics}
+		}
+		loggerWriter := newLoggerWriterAdapter(s.logger, s.cfg.LogLevel, mParser)
 		cmd.Stdout = loggerWriter
 		cmd.Stderr = loggerWriter
+
 		_ = cmd.Run()
 		if ctx.Err() != nil {
 			return nil // context was canceled
@@ -290,12 +304,14 @@ func extractOptionFromFlag(flag string) (string, string, error) {
 type loggerWriterAdapter struct {
 	logger log.Logger
 	level  string
+	parser *logMetricsParser
 }
 
-func newLoggerWriterAdapter(logger log.Logger, level string) loggerWriterAdapter {
+func newLoggerWriterAdapter(logger log.Logger, level string, parser *logMetricsParser) loggerWriterAdapter {
 	return loggerWriterAdapter{
 		logger: logger,
 		level:  level,
+		parser: parser,
 	}
 }
 
@@ -309,6 +325,11 @@ func (adapter loggerWriterAdapter) Write(p []byte) (n int, err error) {
 	for _, msg := range bytes.Split(p, []byte{'\r', '\n'}) {
 		if len(msg) == 0 {
 			continue
+		}
+
+		// if parsing is enabled, create metrics by parsing the log messages
+		if adapter.parser != nil {
+			adapter.parser.parseLogMetrics(msg)
 		}
 
 		// Do not log debug messages if the log level is not debug.


### PR DESCRIPTION
Adds the following metrics

```
# HELP pdc_agent_ssh_channels Number of active SSH channels
# TYPE pdc_agent_ssh_channels gauge
pdc_agent_ssh_open_channels 2

# HELP pdc_agent_ssh_restarts_total Total number of SSH restarts
# TYPE pdc_agent_ssh_restarts_total counter
pdc_agent_ssh_restarts_total{exit_code="255"} 1

# HELP pdc_agent_ssh_time_to_connect_seconds Time spent to establish SSH connection
# TYPE pdc_agent_ssh_time_to_connect_seconds histogram
pdc_agent_ssh_time_to_connect_seconds_bucket{le="+Inf"} 2
pdc_agent_ssh_time_to_connect_seconds_sum 4.082566042
pdc_agent_ssh_time_to_connect_seconds_count 2

# HELP pdc_agent_tcp_connections_total Number of open TCP connections
# TYPE pdc_agent_tcp_connections_total counter
pdc_agent_tcp_connections_total{status="failure",target="127.0.0.1:5432"} 1
pdc_agent_tcp_connections_total{status="success",target="127.0.0.1:5432"} 2
pdc_agent_tcp_connections_total{status="failure",target="prometheus.test"} 5
```