### PR TITLE
Fix typo in code comment

### DIFF
--- a/pkg/ssh/ssh.go
+++ b/pkg/ssh/ssh.go
@@ -246,7 +246,7 @@ func (s *Client) SSHFlagsFromConfig() ([]string, error) {
 	gwURL := s.cfg.URL
 	user := fmt.Sprintf("%s@%s", s.cfg.PDC.HostedGrafanaID, gwURL.String())
 
-	// keep ssh_config parameters in a map so they can be overidden by the user
+	// keep ssh_config parameters in a map so they can be overridden by the user
 	sshOptions := map[string]string{
 		"UserKnownHostsFile":  fmt.Sprintf("%s/%s", keyFileDir, KnownHostsFile),
 		"CertificateFile":     fmt.Sprintf("%s-cert.pub", s.cfg.KeyFile),

--- a/pkg/ssh/ssh_test.go
+++ b/pkg/ssh/ssh_test.go
@@ -130,7 +130,7 @@ func TestFakeSSHCmd(t *testing.T) {
 }
 
 // Building this out to verify behaviour, not exactly sure that the function is
-// hanging off the right struct or organised appropriately.
+// hanging off the right struct or organized appropriately.
 func TestClient_SSHArgs(t *testing.T) {
 	t.Run("defaults", func(t *testing.T) {
 		cfg := ssh.DefaultConfig()


### PR DESCRIPTION
Minor typo fixes in comments.

Changed files:
- pkg/ssh/ssh_test.go
- pkg/ssh/ssh.go


This change does not include functional changes.