### PR TITLE
support env vars for cluster, token and hosted_grafana_id

### DIFF
--- a/cmd/pdc/main.go
+++ b/cmd/pdc/main.go
@@ -63,6 +63,11 @@ func (mf *mainFlags) RegisterFlags(fs *flag.FlagSet) {
 	fs.StringVar(&mf.GatewayFQDN, "gateway-fqdn", "", "FQDN for the PDC Gateway. If set, this will take precedence over the cluster and domain flags")
 
 	fs.BoolVar(&mf.DevMode, "dev-mode", false, "[DEVELOPMENT ONLY] run the agent in development mode")
+
+	// flags should always take precedence over env vars
+	if mf.Cluster == "" {
+		mf.Cluster = os.Getenv("GCLOUD_PDC_CLUSTER")
+	}
 }
 
 // Tries to get the openssh version. Returns "UNKNOWN" on error.

--- a/pkg/pdc/client.go
+++ b/pkg/pdc/client.go
@@ -12,6 +12,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"os"
 	"path"
 	"time"
 
@@ -66,6 +67,14 @@ func (cfg *Config) RegisterFlags(fs *flag.FlagSet) {
 
 	fs.StringVar(&cfg.DevNetwork, "dev-network", "", "[DEVELOPMENT ONLY] the network the agent will connect to")
 	fs.StringVar(&cfg.DevPort, "dev-api-port", "9181", "[DEVELOPMENT ONLY] The port to use for agent connections to the PDC API")
+
+	// flags should always take precedence over env vars
+	if cfg.Token == "" {
+		cfg.Token = os.Getenv("GCLOUD_PDC_SIGNING_TOKEN")
+	}
+	if cfg.HostedGrafanaID == "" {
+		cfg.HostedGrafanaID = os.Getenv("GCLOUD_HOSTED_GRAFANA_ID")
+	}
 }
 
 // Client is a PDC API client


### PR DESCRIPTION
closes https://github.com/grafana/pdc-agent/issues/157

These are the env vars we have documented [here](https://grafana.com/docs/grafana-cloud/connect-externally-hosted/private-data-source-connect/configure-pdc/#pdc-connection-steps), so we should definitely be supporting these.

command line flags take precedence over env vars