### PR TITLE
Chore: use shared workflow to log into dockerhub

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,12 +31,8 @@ jobs:
         uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-      # login to docker hub
-      - uses: docker/login-action@v3
-        name: Login to Docker Hub
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Login to DockerHub
+        uses: grafana/shared-workflows/actions/dockerhub-login@dockerhub-login/v1.0.2
       - uses: goreleaser/goreleaser-action@v6
         with:
           distribution: goreleaser


### PR DESCRIPTION
Use shared workflow instead of GHA secrets, then we can remove the secrets.