### PR TITLE
Bump golangci-lint

### DIFF
--- a/.github/workflows/go_lint.yml
+++ b/.github/workflows/go_lint.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           persist-credentials: false
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@55c2c1448f86e01eaae002a5a3a9624417608d84 # v6.5.2
+        uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 # v8.0.0
         with:
           version: latest
           args: --max-same-issues=0 --max-issues-per-linter=0

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,150 +1,108 @@
-linters-settings:
-  govet:
-    enable:
-      - shadow
-  gocyclo:
-    min-complexity: 10
-  gocritic:
-    disabled-checks:
-      - commentFormatting
-  dupl:
-    threshold: 100
-  goconst:
-    min-len: 2
-    min-occurrences: 4
-  lll:
-    line-length: 140
-  nolintlint:
-    allow-unused: false # report any unused nolint directives
-    require-explanation: false # don't require an explanation for nolint directives
-    require-specific: false # don't require nolint directives to be specific about which linter is being skipped
-  errcheck:
-    exclude-functions: 
-      - io/ioutil.WriteFile
-      - io/ioutil.ReadFile
-      - (github.com/go-kit/log.Logger).Log
-      - io.Copy
-      - (github.com/opentracing/opentracing-go.Tracer).Inject
-  gocognit:
-    min-complexity: 31
-  gomoddirectives:
-    replace-allow-list:
-      # see https://github.com/dolthub/go-mysql-server/issues/1591
-      - github.com/dolthub/go-mysql-server
-
+version: "2"
+run:
+  concurrency: 4
+  go: "1.17"
+  build-tags:
+    - ""
+    - integration
 linters:
-  disable-all: true
+  default: none
   enable:
     - asasalint
     - asciicheck
     - bidichk
     - bodyclose
     - containedctx
-    ## - contextcheck
-    ## - cyclop
-    ## - decorder
-    # - depguard
-    # - dogsled
     - dupl
     - dupword
     - durationcheck
     - errcheck
-    # - errchkjson
     - errname
     - errorlint
-    ## - execinquery
-    # - exhaustive
-    ## - exhaustruct
-    ## - forbidigo
-    ## - forcetypeassert
-    # - funlen
-    # - gci
-    # - gochecknoglobals
-    # - gochecknoinits
     - gocognit
     - goconst
     - gocritic
-    # - gocyclo
-    ## - godot
-    # - godox
-    ## - goerr113
-    - gofmt
-    # - gofumpt
     - goheader
-    - goimports
-    # - gomnd
     - gomoddirectives
     - gomodguard
     - goprintffuncname
-    # - gosec
-    - gosimple
     - govet
-    ## - grouper
     - importas
     - ineffassign
-    ## - interfacebloat
-    # - interfacer
-    # - ireturn
-    # - lll
     - loggercheck
-    ## - maintidx
     - makezero
     - misspell
     - nakedret
     - nestif
-    # - nilerr
-    ## - nilnil
-    # - nlreturn
     - noctx
     - nolintlint
-    ## - nonamedreturns
     - nosprintfhostport
-    ## - paralleltest
     - prealloc
     - predeclared
     - promlinter
     - reassign
-    - revive
     - rowserrcheck
     - sqlclosecheck
     - staticcheck
-    - stylecheck
-    # - tagliatelle
-    - tenv
     - testableexamples
-    # - testpackage
-    ## - thelper
     - tparallel
-    - typecheck
     - unconvert
     - unparam
     - unused
     - usestdlibvars
-    # - varnamelen
-    ## - wastedassign
-    # - whitespace
-    # - wrapcheck
-    # - wsl
-
-issues:
-  # Excluding configuration per-path, per-linter, per-text and per-source
-  exclude-rules:
-    - path: _test\.go
-      linters:
-        - govet
-        - dupl
-        # - goerr113
-  exclude-dirs:
-    - internal/proxyproto
-
-run:
-  concurrency: 4
-  timeout: 5m
-  build-tags:
-    - ""
-    - integration
-  # use Go 1.17 linter behaviour because we don't use generics - see
-  # https://github.com/golangci/golangci-lint/issues/2649 for details - this can
-  # be removed once that issue is resolved, or if we decide to use generics -
-  # the downside is some linters are disabled for 1.18
-  go: '1.17'
+  settings:
+    dupl:
+      threshold: 100
+    errcheck:
+      exclude-functions:
+        - io/ioutil.WriteFile
+        - io/ioutil.ReadFile
+        - (github.com/go-kit/log.Logger).Log
+        - io.Copy
+        - (github.com/opentracing/opentracing-go.Tracer).Inject
+    gocognit:
+      min-complexity: 31
+    goconst:
+      min-len: 2
+      min-occurrences: 4
+    gocritic:
+      disabled-checks:
+        - commentFormatting
+    gocyclo:
+      min-complexity: 10
+    gomoddirectives:
+      replace-allow-list:
+        - github.com/dolthub/go-mysql-server
+    govet:
+      enable:
+        - shadow
+    lll:
+      line-length: 140
+    nolintlint:
+      require-explanation: false
+      require-specific: false
+      allow-unused: false
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    rules:
+      - linters:
+          - dupl
+          - govet
+        path: _test\.go
+    paths:
+      - internal/proxyproto
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$


### PR DESCRIPTION
This PR bumps the GH `golangci-lint` action from `v.6.5.2` to `v8.0.0`: https://github.com/golangci/golangci-lint-action/releases/tag/v8.0.0.

It also updates `.golangci.yml` to use the new configuration spec (automatically migrated with `golangci-lint migrate` command). Note that some linters were deprecated.