### PR TITLE
Update-go-stdlib-1.24.4

### DIFF
--- a/.github/workflows/go_build.yml
+++ b/.github/workflows/go_build.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.21"
+          go-version: "1.24.4"
       - uses: actions/checkout@v4
         with:
           persist-credentials: false

--- a/.github/workflows/go_lint.yml
+++ b/.github/workflows/go_lint.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.21"
+          go-version: "1.24.4"
       - uses: actions/checkout@v4
         with:
           persist-credentials: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
       - run: git fetch --force --tags
       - uses: actions/setup-go@v5
         with:
-          go-version: ">=1.19.5"
+          go-version: ">=1.24.4"
           cache: false
       # setup docker buildx
       - name: Set up QEMU

--- a/.go-build-tags
+++ b/.go-build-tags
@@ -1,0 +1,1 @@
+osusergo netgo static_build

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -19,6 +19,12 @@ builds:
       - "386"
       - amd64
       - arm64
+    ldflags:
+      - -s -w
+    tags:
+      - osusergo
+      - netgo
+      - static_build
 
 
 archives:

--- a/Makefile
+++ b/Makefile
@@ -3,10 +3,10 @@ BINARY_NAME=pdc
 all: lint build test
 
 build:
-	go build -tags="$(shell cat .go-build-tags)" -ldflags="-s -w" -o ${BINARY_NAME} ./cmd/pdc/
+	go build -o ${BINARY_NAME} ./cmd/pdc/
 
 test:
-	GOOS=darwin GOARCH=amd64 CGO_CFLAGS="-Wno-error" go test -tags="$(shell cat .go-build-tags)" -timeout=5m -race -coverprofile=c.out ./...
+	go test -timeout=5m -race -coverprofile=c.out ./...
 
 lint:
 	golangci-lint run --max-same-issues=0 --max-issues-per-linter=0

--- a/Makefile
+++ b/Makefile
@@ -3,10 +3,10 @@ BINARY_NAME=pdc
 all: lint build test
 
 build:
-	go build -o ${BINARY_NAME} ./cmd/pdc/
+	go build -tags="$(shell cat .go-build-tags)" -ldflags="-s -w" -o ${BINARY_NAME} ./cmd/pdc/
 
 test:
-	go test -timeout=5m -race -coverprofile=c.out ./...
+	GOOS=darwin GOARCH=amd64 CGO_CFLAGS="-Wno-error" go test -tags="$(shell cat .go-build-tags)" -timeout=5m -race -coverprofile=c.out ./...
 
 lint:
 	golangci-lint run --max-same-issues=0 --max-issues-per-linter=0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/pdc-agent
 
-go 1.24.1
+go 1.24.4
 
 require (
 	github.com/go-kit/log v0.2.1


### PR DESCRIPTION
Updated go.mod prerequisites to go stdlib v1.24.4 to address vulnerabilities identified in v1.24.1:

https://scout.docker.com/v/CVE-2025-22871
https://scout.docker.com/v/CVE-2025-22874
https://scout.docker.com/v/CVE-2025-4673
https://scout.docker.com/v/CVE-2025-0913