### PR TITLE
Update Go version to 1.24.4

### DIFF
--- a/.github/workflows/go_build.yml
+++ b/.github/workflows/go_build.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.21"
+          go-version: "1.24.4"
       - uses: actions/checkout@v4
         with:
           persist-credentials: false

--- a/.github/workflows/go_lint.yml
+++ b/.github/workflows/go_lint.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.21"
+          go-version: "1.24.4"
       - uses: actions/checkout@v4
         with:
           persist-credentials: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
       - run: git fetch --force --tags
       - uses: actions/setup-go@v5
         with:
-          go-version: ">=1.19.5"
+          go-version: "1.24.4"
           cache: false
       # setup docker buildx
       - name: Set up QEMU

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/pdc-agent
 
-go 1.24.1
+go 1.24.4
 
 require (
 	github.com/go-kit/log v0.2.1


### PR DESCRIPTION
Update go.mod and GitHub workflow scripts to use GO version 1.24.4 and address the following CVEs present in version 1.24.1:

https://scout.docker.com/v/CVE-2025-22871
https://scout.docker.com/v/CVE-2025-22874
https://scout.docker.com/v/CVE-2025-4673
https://scout.docker.com/v/CVE-2025-0913