### PR TITLE
add zizmor config to allow running zizmor CI from forks

### DIFF
--- a/.github/.zizmor.yml
+++ b/.github/.zizmor.yml
@@ -1,0 +1,9 @@
+# This is also used as the default configuration for the Zizmor reusable
+# workflow.
+
+rules:
+  unpinned-uses:
+    config:
+      policies:
+        actions/*: any # trust GitHub
+        grafana/*: any # trust Grafana


### PR DESCRIPTION
PR https://github.com/grafana/pdc-agent/pull/177 fails the zizmor check because its from a fork. This config allows zizmor to run OK on PRs from forks