### PR TITLE
Upgrade packages in alpine

### DIFF
--- a/cmd/pdc/Dockerfile
+++ b/cmd/pdc/Dockerfile
@@ -1,5 +1,6 @@
-FROM alpine:3.22
-RUN apk update && apk upgrade --no-cache
+FROM alpine:3.22.2
+RUN apk update
+RUN apk add busybox=1.37.0-r20
 RUN apk add --no-cache --repository=http://dl-cdn.alpinelinux.org/alpine/edge/main openssh
 COPY pdc /usr/bin/pdc
 RUN addgroup -g 30000 pdc && adduser -G pdc -u 30000 pdc -D


### PR DESCRIPTION
I believe alpine 3.22 has a few dependencies with security issues, I think if we add this it should bump any dependencies to the latest version.