### PR TITLE
tune: warn on high channel count

### DIFF
--- a/pkg/ssh/ssh.go
+++ b/pkg/ssh/ssh.go
@@ -198,6 +198,7 @@ func (s *Client) starting(ctx context.Context) error {
 					m:          s.metrics,
 					connStart:  startTime,
 					connection: fmt.Sprintf("%d", connectionID),
+					logger:     s.logger,
 				}
 			}
 


### PR DESCRIPTION
Threw a k6 load test at this and saw the log come through once the threshold was hit: 

```
level=warn caller=metrics.go:100 ts=2026-01-22T16:11:06.133701532-05:00 msg="high channel count" count=101 hint="consider increasing -connections"
```