### PR TITLE
renamed metrics package to pdcmetrics

### DIFF
--- a/cmd/pdc/main.go
+++ b/cmd/pdc/main.go
@@ -19,8 +19,8 @@ import (
 	"github.com/go-kit/log/level"
 
 	"github.com/grafana/dskit/services"
-	"github.com/grafana/pdc-agent/pkg/metrics"
 	"github.com/grafana/pdc-agent/pkg/pdc"
+	"github.com/grafana/pdc-agent/pkg/pdcmetrics"
 	"github.com/grafana/pdc-agent/pkg/ssh"
 	"github.com/prometheus/client_golang/prometheus"
 )
@@ -206,7 +206,7 @@ func run(logger log.Logger, sshConfig *ssh.Config, pdcConfig *pdc.Config) error 
 	}
 
 	// If ssh client start successfully, start the metrics server
-	ms := metrics.NewMetricsServer(logger, sshConfig.MetricsAddr)
+	ms := pdcmetrics.NewMetricsServer(logger, sshConfig.MetricsAddr)
 	go ms.Run()
 
 	// Wait for the ssh client to exit

--- a/pkg/pdc/metrics.go
+++ b/pkg/pdc/metrics.go
@@ -1,7 +1,7 @@
 package pdc
 
 import (
-	"github.com/grafana/pdc-agent/pkg/metrics"
+	"github.com/grafana/pdc-agent/pkg/pdcmetrics"
 	"github.com/prometheus/client_golang/prometheus"
 )
 
@@ -11,7 +11,7 @@ type promMetrics struct {
 
 func newPromMetrics() *promMetrics {
 	return &promMetrics{
-		signingRequests: metrics.NewNativeHistogramVec(
+		signingRequests: pdcmetrics.NewNativeHistogramVec(
 			prometheus.HistogramOpts{
 				Name:      "signing_requests_duration_seconds",
 				Help:      "Duration of signing requests in seconds",

--- a/pkg/pdcmetrics/metrics.go
+++ b/pkg/pdcmetrics/metrics.go
@@ -1,4 +1,4 @@
-package metrics
+package pdcmetrics
 
 import (
 	"errors"

--- a/pkg/pdcmetrics/utils.go
+++ b/pkg/pdcmetrics/utils.go
@@ -1,4 +1,4 @@
-package metrics
+package pdcmetrics
 
 import (
 	"time"

--- a/pkg/ssh/metrics.go
+++ b/pkg/ssh/metrics.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
-	"github.com/grafana/pdc-agent/pkg/metrics"
+	"github.com/grafana/pdc-agent/pkg/pdcmetrics"
 
 	"github.com/prometheus/client_golang/prometheus"
 )
@@ -61,7 +61,7 @@ func newPromMetrics() *promMetrics {
 			},
 			[]string{"connection", "target", "status"},
 		),
-		timeToConnect: metrics.NewNativeHistogramVec(
+		timeToConnect: pdcmetrics.NewNativeHistogramVec(
 			prometheus.HistogramOpts{
 				Name:      "ssh_time_to_connect_seconds",
 				Help:      "Time spent to establish SSH connection",


### PR DESCRIPTION
the linter complained about the package named `metrics`:

```
Error: pkg/metrics/utils.go:1:9: var-naming: avoid package names that conflict with Go standard library package names (revive)
  package metrics
```

i renamed it to `pdcmetrics`. i'm not happy with the new name, but i don't have anything better. i'm open to recommendations.