### PR TITLE
disable linter-rule for package

### DIFF
--- a/pkg/metrics/utils.go
+++ b/pkg/metrics/utils.go
@@ -1,4 +1,4 @@
-package metrics
+package metrics //nolint:revive
 
 import (
 	"time"


### PR DESCRIPTION
the linter complains that the package name `metrics` conflicts with the name of a package in the go stdlib.

we will silence the warning for now.