### PR TITLE
Unpin docker version

### DIFF
--- a/cmd/pdc/Dockerfile
+++ b/cmd/pdc/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.23@sha256:25109184c71bdad752c8312a8623239686a9a2071e8825f20acb8f2198c3f659
+FROM alpine:3.23.3
 RUN apk update && apk upgrade
 RUN apk add openssh
 COPY pdc /usr/bin/pdc


### PR DESCRIPTION
I believe there have been some fixes to 3.23 that we are not getting if we have this pinned