### PR TITLE
feat: add ability to use Go's ssh library.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,9 +14,11 @@ require (
 )
 
 require (
+	github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
+	github.com/gliderlabs/ssh v0.3.8 // indirect
 	github.com/go-logfmt/logfmt v0.6.0 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
 	github.com/kr/text v0.2.0 // indirect
@@ -26,6 +28,7 @@ require (
 	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.67.5 // indirect
 	github.com/prometheus/procfs v0.19.2 // indirect
+	github.com/things-go/go-socks5 v0.1.0 // indirect
 	go.uber.org/atomic v1.11.0 // indirect
 	go.yaml.in/yaml/v2 v2.4.3 // indirect
 	golang.org/x/sys v0.40.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be h1:9AeTilPcZAjCFIImctFaOjnTIavg87rW78vTPkQqLI8=
+github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be/go.mod h1:ySMOLuWl6zY27l47sB3qLNK6tF2fkHG55UZxx8oIVo4=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
@@ -7,6 +9,8 @@ github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/fatih/color v1.16.0 h1:zmkK9Ngbjj+K0yRhTVONQh1p/HknKYSlNT+vZCzyokM=
 github.com/fatih/color v1.16.0/go.mod h1:fL2Sau1YI5c0pdGEVCbKQbLXB6edEj1ZgiY4NijnWvE=
+github.com/gliderlabs/ssh v0.3.8 h1:a4YXD1V7xMF9g5nTkdfnja3Sxy1PVDCj1Zg4Wb8vY6c=
+github.com/gliderlabs/ssh v0.3.8/go.mod h1:xYoytBv1sV0aL3CavoDuJIQNURXkkfPA/wxQ1pL1fAU=
 github.com/go-kit/log v0.2.1 h1:MRVx0/zhvdseW+Gza6N9rVzU/IVzaeE1SFI4raAhmBU=
 github.com/go-kit/log v0.2.1/go.mod h1:NwTd00d/i8cPZ3xOwwiv2PO5MOcx78fFErGNcVmBjv0=
 github.com/go-logfmt/logfmt v0.6.0 h1:wGYYu3uicYdqXVgoYbvnkrPVXkuLM1p1ifugDMEdRi4=
@@ -53,6 +57,8 @@ github.com/rogpeppe/go-internal v1.10.0 h1:TMyTOH3F/DB16zRVcYyreMH6GnZZrwQVAoYjR
 github.com/rogpeppe/go-internal v1.10.0/go.mod h1:UQnix2H7Ngw/k4C5ijL5+65zddjncjaFoBhdsK/akog=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
+github.com/things-go/go-socks5 v0.1.0 h1:4f5dz0iMQ6cA4wseFmyLmCHmg3SWJTW92ndrKS6oERg=
+github.com/things-go/go-socks5 v0.1.0/go.mod h1:Riabiyu52kLsla0YmJqunt1c1JEl6iXSr4bRd7swFEA=
 go.uber.org/atomic v1.11.0 h1:ZvwS0R+56ePWxUNi+Atn9dWONBPp/AUETXlHW0DxSjE=
 go.uber.org/atomic v1.11.0/go.mod h1:LUxbIzbOniOlMKjJjyPfpl4v+PKK2cNJn91OQbhoJI0=
 go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=

--- a/pkg/ssh/channel_listener.go
+++ b/pkg/ssh/channel_listener.go
@@ -1,0 +1,153 @@
+package ssh
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"sync"
+	"syscall"
+	"time"
+
+	"golang.org/x/crypto/ssh"
+)
+
+// NewListenerFromChannel creates a net.Listener that listens for new
+// requests on an ssh channel and converts the request to a net.Conn. The connection
+// that received the channel is required for implementing the net.Conn interface.
+func NewListenerFromChannel(parent ssh.Conn, nc <-chan ssh.NewChannel, promMetrics *promMetrics) net.Listener {
+	return &listener{
+		parent:  parent,
+		nc:      nc,
+		metrics: *promMetrics,
+	}
+}
+
+// listener implements net.Listener
+type listener struct {
+	nc     <-chan ssh.NewChannel
+	parent ssh.Conn
+
+	mu         sync.RWMutex
+	chanclosed bool
+	metrics    promMetrics
+}
+
+func (l *listener) ok() bool {
+	l.mu.RLock()
+	defer l.mu.RUnlock()
+	return !l.chanclosed && l.parent != nil
+}
+
+func (l *listener) Accept() (net.Conn, error) {
+	if !l.ok() {
+		return nil, syscall.EINVAL
+	}
+
+	nc := <-l.nc
+
+	// channel close event. Error here as we don't want to try and do something
+	// with the event
+	if nc == nil {
+		l.mu.Lock()
+		l.chanclosed = true
+		l.mu.Unlock()
+		return nil, errors.New("ssh.NewChannel channel closed")
+	}
+
+	ch, reqs, err := (nc).Accept()
+	if err != nil {
+		return nil, err
+	}
+	l.metrics.goOpenChannelsCount.Inc()
+
+	go ssh.DiscardRequests(reqs)
+
+	return ToNetConn(l.parent, ch, l), nil
+}
+
+func (l *listener) Addr() net.Addr {
+	return l.parent.LocalAddr()
+}
+
+func (l *listener) Close() error {
+	return nil
+}
+
+// ToNetConn converts an ssh connection and associated channel to a net.Conn
+func ToNetConn(parent ssh.Conn, ch ssh.Channel, l *listener) net.Conn {
+	return &channel{
+		Channel:    ch,
+		parentConn: parent,
+		metrics:    l.metrics,
+	}
+}
+
+// channel implements net.Conn
+type channel struct {
+	ssh.Channel
+	parentConn       ssh.Conn
+	deadline         *time.Timer
+	deadlineCanceled chan struct{}
+	mu               sync.Mutex
+	metrics          promMetrics
+	// we only want to do teardown one time
+	closeOnce sync.Once
+}
+
+func (c *channel) Close() (err error) {
+	c.closeOnce.Do(func() {
+		c.metrics.goOpenChannelsCount.Dec()
+
+		err = c.Channel.Close()
+	})
+
+	return err
+}
+
+// LocalAddr returns the local network address.
+func (c *channel) LocalAddr() net.Addr {
+	return c.parentConn.LocalAddr()
+}
+
+// RemoteAddr returns the remote network address.
+func (c *channel) RemoteAddr() net.Addr {
+	return c.parentConn.RemoteAddr()
+}
+
+// SetDeadline sets the read and write deadlines associated with the connection.
+func (c *channel) SetDeadline(t time.Time) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	// Stop the time if it's already running
+	if c.deadline != nil {
+		c.deadline.Stop()
+		close(c.deadlineCanceled)
+		c.deadline = nil
+	}
+	// If t is zero, we don't want to set a deadline
+	if t.IsZero() {
+		return nil
+	}
+	// Set the deadline
+	c.deadline = time.NewTimer(time.Until(t))
+	c.deadlineCanceled = make(chan struct{})
+	go func(deadline *time.Timer, deadlineCanceled <-chan struct{}) {
+		select {
+		case <-deadline.C:
+			_ = c.Close()
+		case <-deadlineCanceled:
+			return
+		}
+	}(c.deadline, c.deadlineCanceled)
+	return nil
+}
+
+// A zero value for t means I/O operations will not time out.
+func (c *channel) SetReadDeadline(_ time.Time) error {
+	return fmt.Errorf("not implemented")
+}
+
+// A zero value for t means I/O operations will not time out.
+func (c *channel) SetWriteDeadline(_ time.Time) error {
+	return fmt.Errorf("not implemented")
+}

--- a/pkg/ssh/keepalive.go
+++ b/pkg/ssh/keepalive.go
@@ -1,0 +1,85 @@
+package ssh
+
+import (
+	"context"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+	"golang.org/x/crypto/ssh"
+)
+
+// doKeepAlives performs a continuous keepAlive to the server. We use this
+// instead of Server.sshServer's IdleTimeout because the IdleTimeout is reset
+// whenever something is written to the Connection (even if it fails): If we
+// keep writing to an invalid connection, it will not time out.
+//
+// doKeepAlives uses a similar approach to OpenSSH. It sends a global request
+// every interval and expects a reply within timeout time. If we hit the max
+// failure count, it closes the connection. The only difference to OpenSSH is
+// that these keepalives keep sending when other requests are being sent - this
+// is just to make the code simpler.
+func doKeepAlives(ctx context.Context, conn ssh.Conn, logger log.Logger) {
+	interval := 15 * time.Second
+	timeout := 5 * time.Second
+	maxFailures := 3
+
+	failures := 0
+
+	t := time.NewTicker(interval)
+	defer t.Stop()
+	for {
+		<-t.C
+
+		if ctx.Err() != nil {
+			return
+		}
+
+		rctx, cancel := context.WithTimeout(ctx, timeout)
+		err := sendKeepAliveRequest(rctx, conn, logger)
+		cancel()
+
+		if err == nil {
+			failures = 0
+			continue
+		}
+
+		failures++
+		if failures >= maxFailures {
+			level.Debug(logger).Log("msg", "client keepalive failures reached, closing connection", "remote", conn.RemoteAddr())
+			conn.Close()
+			return
+		}
+	}
+}
+
+// sendKeepAliveRequest sends a global request to the client, and awaits *any*
+// response. If the context cancels before we get a response, it returns the
+// context error. If the request fails to send, it will eventually return the
+// context error.
+//
+// These requests will show up on the client as packet type 80, and the client
+// will response with packet type 82. This is the same behaviour as openSSH
+// performs with ServerAliveInterval
+func sendKeepAliveRequest(ctx context.Context, conn ssh.Conn, logger log.Logger) error {
+	successCh := make(chan struct{}, 1)
+
+	go func(c ssh.Conn, ch chan struct{}) {
+		level.Debug(logger).Log("msg", "sending keepalive")
+		_, _, err := c.SendRequest("keepalive", true, []byte{})
+
+		// if the request failed to send, dont count it as a response
+		if err != nil {
+			return
+		}
+		ch <- struct{}{}
+		close(ch)
+	}(conn, successCh)
+
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-successCh:
+		return nil
+	}
+}

--- a/pkg/ssh/metrics.go
+++ b/pkg/ssh/metrics.go
@@ -26,6 +26,7 @@ type promMetrics struct {
 	tcpConnectionsCount *prometheus.CounterVec // connections to the target host
 	timeToConnect       *prometheus.HistogramVec
 	openChannelsCount   *prometheus.GaugeVec
+	goOpenChannelsCount prometheus.Gauge
 }
 
 func newPromMetrics() *promMetrics {
@@ -68,6 +69,13 @@ func newPromMetrics() *promMetrics {
 				Namespace: "pdc_agent",
 			},
 			[]string{"connection"},
+		),
+		goOpenChannelsCount: prometheus.NewGauge(
+			prometheus.GaugeOpts{
+				Name:      "go_open_channels_count",
+				Help:      "Total number of gossh channels",
+				Namespace: "pdc_agent",
+			},
 		),
 	}
 }

--- a/pkg/ssh/metrics.go
+++ b/pkg/ssh/metrics.go
@@ -72,7 +72,7 @@ func newPromMetrics() *promMetrics {
 		),
 		goOpenChannelsCount: prometheus.NewGauge(
 			prometheus.GaugeOpts{
-				Name:      "go_open_channels_count",
+				Name:      "go_open_channels",
 				Help:      "Total number of gossh channels",
 				Namespace: "pdc_agent",
 			},

--- a/pkg/ssh/permit_remote_open.go
+++ b/pkg/ssh/permit_remote_open.go
@@ -1,0 +1,74 @@
+package ssh
+
+import (
+	"context"
+	"net"
+	"slices"
+	"strconv"
+	"strings"
+
+	"github.com/things-go/go-socks5"
+	statute "github.com/things-go/go-socks5/statute"
+)
+
+type PermitRemoteOpen struct {
+	Domains []string
+}
+
+// Allow socks5.WithRule doesn't allow multiple rules, so we need to combine our rules here.
+// 1. We only allow `CONNECT` commands, not `BIND` or `ASSOCIATE`.
+// 2. We support domain filtering via the new -permit-domains flag.
+// We make a best effort to support `-ssh-flag='-o PermitRemoteOpen=mysql.example.com:3306` style as well.
+func (p *PermitRemoteOpen) Allow(ctx context.Context, req *socks5.Request) (context.Context, bool) {
+	// we only allow CONNECT
+	if req.Command != statute.CommandConnect {
+		return ctx, false
+	}
+
+	// no domains specified means accept all
+	if len(p.Domains) < 1 {
+		return ctx, true
+	}
+
+	// lowercase domains so we can compare
+	var domains []string
+	for _, d := range p.Domains {
+		domains = append(domains, strings.ToLower(d))
+	}
+	host := strings.ToLower(req.RawDestAddr.FQDN)
+
+	if host == "" {
+		host = req.RawDestAddr.IP.String()
+	}
+
+	if slices.Contains(domains, host) {
+		return ctx, true
+	}
+
+	// account for ports
+	if req.RawDestAddr.Port > 0 {
+		host = net.JoinHostPort(host, strconv.Itoa(req.RawDestAddr.Port))
+	}
+
+	if slices.Contains(domains, host) {
+		return ctx, true
+	}
+
+	return ctx, false
+}
+
+// MapSSHPermitToSocks maps sshFlags for PermitRemoteOpen to -domains
+func MapSSHPermitToSocks(sshFlags []string) (domains []string, err error) {
+	for _, f := range sshFlags {
+		name, value, err := extractOptionFromFlag(f)
+		if err != nil {
+			return nil, err
+		}
+		if name == "PermitRemoteOpen" {
+			for domain := range strings.SplitSeq(value, " ") {
+				domains = append(domains, domain)
+			}
+		}
+	}
+	return domains, nil
+}

--- a/pkg/ssh/permit_remote_open.go
+++ b/pkg/ssh/permit_remote_open.go
@@ -31,9 +31,9 @@ func (p *PermitRemoteOpen) Allow(ctx context.Context, req *socks5.Request) (cont
 	}
 
 	// lowercase domains so we can compare
-	var domains []string
-	for _, d := range p.Domains {
-		domains = append(domains, strings.ToLower(d))
+	domains := make([]string, len(p.Domains))
+	for i, d := range p.Domains {
+		domains[i] = strings.ToLower(d)
 	}
 	host := strings.ToLower(req.RawDestAddr.FQDN)
 

--- a/pkg/ssh/permit_remote_open_test.go
+++ b/pkg/ssh/permit_remote_open_test.go
@@ -1,0 +1,83 @@
+package ssh
+
+import (
+	"context"
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/things-go/go-socks5"
+	statute "github.com/things-go/go-socks5/statute"
+)
+
+func TestMapSSHPermitToSocks(t *testing.T) {
+	domains, err := MapSSHPermitToSocks([]string{"-o PermitRemoteOpen=foo:9000 bar"})
+	assert.NoError(t, err)
+	assert.Equal(t, []string{"foo:9000", "bar"}, domains)
+}
+
+func TestPermitRemoteOpenAllow(t *testing.T) {
+	tests := []struct {
+		name    string
+		domains []string
+		command byte
+		addr    *statute.AddrSpec
+		allow   bool
+	}{
+		{
+			name:    "rejects non-connect",
+			domains: nil,
+			command: statute.CommandBind,
+			addr:    &statute.AddrSpec{FQDN: "example.com", Port: 443},
+			allow:   false,
+		},
+		{
+			name:    "allows all when no domains configured",
+			domains: nil,
+			command: statute.CommandConnect,
+			addr:    &statute.AddrSpec{FQDN: "example.com", Port: 443},
+			allow:   true,
+		},
+		{
+			name:    "matches fqdn case insensitively",
+			domains: []string{"example.com"},
+			command: statute.CommandConnect,
+			addr:    &statute.AddrSpec{FQDN: "EXAMPLE.COM", Port: 443},
+			allow:   true,
+		},
+		{
+			name:    "matches host and port",
+			domains: []string{"example.com:443"},
+			command: statute.CommandConnect,
+			addr:    &statute.AddrSpec{FQDN: "example.com", Port: 443},
+			allow:   true,
+		},
+		{
+			name:    "matches ip when fqdn is empty",
+			domains: []string{"10.0.0.5"},
+			command: statute.CommandConnect,
+			addr:    &statute.AddrSpec{IP: net.ParseIP("10.0.0.5"), Port: 443},
+			allow:   true,
+		},
+		{
+			name:    "rejects unmatched destination",
+			domains: []string{"example.com:443"},
+			command: statute.CommandConnect,
+			addr:    &statute.AddrSpec{FQDN: "example.com", Port: 8443},
+			allow:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rule := &PermitRemoteOpen{Domains: tt.domains}
+			req := &socks5.Request{
+				Request:     statute.Request{Command: tt.command},
+				RawDestAddr: tt.addr,
+			}
+
+			_, allowed := rule.Allow(context.Background(), req)
+			assert.Equal(t, tt.allow, allowed)
+		})
+	}
+}

--- a/pkg/ssh/ssh.go
+++ b/pkg/ssh/ssh.go
@@ -23,6 +23,7 @@ import (
 	"github.com/grafana/pdc-agent/pkg/pdc"
 	"github.com/grafana/pdc-agent/pkg/retry"
 	"github.com/prometheus/client_golang/prometheus"
+	"golang.org/x/crypto/ssh"
 )
 
 const (
@@ -64,6 +65,13 @@ type Config struct {
 	// Used for local development.
 	// DevPort is the port number for the PDC gateway
 	DevPort int
+
+	// Use Go-based SSH instead of OpenSSH
+	GoSSH bool
+
+	PermitDomains []string
+
+	ConnectionTimeout time.Duration
 }
 
 // DefaultConfig returns a Config with some sensible defaults set
@@ -86,6 +94,7 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	def := DefaultConfig()
 
 	cfg.SSHFlags = []string{}
+	cfg.PermitDomains = []string{}
 	f.StringVar(&cfg.KeyFile, "ssh-key-file", def.KeyFile, "The path to the SSH key file.")
 	f.BoolVar(&cfg.SkipSSHValidation, "skip-ssh-validation", false, "Ignore openssh minimum version constraints.")
 	f.Func("ssh-flag", "Additional flags to be passed to ssh. Can be set more than once.", cfg.addSSHFlag)
@@ -97,12 +106,19 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	f.IntVar(&cfg.Connections, "connections", 1, "The number of parallel ssh connections to open. Adding more connections will increase total bandwidth to your network. The limit is 50 connections across all your agents")
 
 	f.IntVar(&cfg.DevPort, "dev-ssh-port", 2244, "[DEVELOPMENT ONLY] The port to use for agent connections to the PDC SSH gateway")
-
+	f.BoolVar(&cfg.GoSSH, "use-gossh", false, "Use Go-based SSH. Defaults to OpenSSH.")
+	f.Func("permit-domains", "List of domains that are allowed to recieve queries (defaults to 'all')", cfg.buildDomains)
+	f.DurationVar(&cfg.ConnectionTimeout, "connect-timeout", 1*time.Second, "Specifies the timeout (in seconds) used when connecting. Simliar to ConnectTimeout in OpenSSH.")
 }
 
 func (cfg Config) KeyFileDir() string {
 	dir, _ := path.Split(cfg.KeyFile)
 	return dir
+}
+
+func (cfg *Config) buildDomains(s string) error {
+	cfg.PermitDomains = append(cfg.PermitDomains, s)
+	return nil
 }
 
 func (cfg *Config) addSSHFlag(s string) error {
@@ -113,11 +129,13 @@ func (cfg *Config) addSSHFlag(s string) error {
 // Client is a client for ssh. It configures and runs ssh commands
 type Client struct {
 	*services.BasicService
-	cfg     *Config
-	SSHCmd  string // SSH command to run, defaults to "ssh". Require for testing.
-	logger  log.Logger
-	km      *KeyManager
-	metrics *promMetrics
+	cfg         *Config
+	SSHCmd      string // SSH command to run, defaults to "ssh". Require for testing.
+	logger      log.Logger
+	km          *KeyManager
+	metrics     *promMetrics
+	forwardPort *uint32
+	sshClient   *ssh.Client
 }
 
 // NewClient returns a new SSH client in an idle state
@@ -140,6 +158,7 @@ func (s *Client) Collect(ch chan<- prometheus.Metric) {
 	s.metrics.tcpConnectionsCount.Collect(ch)
 	s.metrics.timeToConnect.Collect(ch)
 	s.metrics.sshConnectionsCount.Collect(ch)
+	s.metrics.goOpenChannelsCount.Collect(ch)
 }
 
 func (s *Client) Describe(ch chan<- *prometheus.Desc) {
@@ -148,12 +167,25 @@ func (s *Client) Describe(ch chan<- *prometheus.Desc) {
 	s.metrics.tcpConnectionsCount.Describe(ch)
 	s.metrics.timeToConnect.Describe(ch)
 	s.metrics.sshConnectionsCount.Describe(ch)
+	s.metrics.goOpenChannelsCount.Describe(ch)
 }
 
 func (s *Client) starting(ctx context.Context) error {
 	level.Info(s.logger).Log("msg", "starting ssh client")
 
-	if !s.cfg.SkipSSHValidation {
+	if !s.cfg.GoSSH && len(s.cfg.PermitDomains) > 0 {
+		level.Warn(s.logger).Log("msg", "-permit-domains must be used with -use-gossh.")
+	}
+
+	if !s.cfg.GoSSH && s.cfg.ConnectionTimeout > time.Second*1 {
+		level.Warn(s.logger).Log("msg", "-connect-timeout must be used with -use-gossh.")
+	}
+
+	if s.cfg.GoSSH && s.cfg.Connections > 1 {
+		level.Warn(s.logger).Log("msg", "-use-gossh doesn't respect the -connections flag currently")
+	}
+
+	if !s.cfg.GoSSH && !s.cfg.SkipSSHValidation {
 		if err := validateSSHVersion(ctx, s.logger, s.SSHCmd); err != nil {
 			return fmt.Errorf("invalid SSH version: %w", err)
 		}
@@ -169,8 +201,23 @@ func (s *Client) starting(ctx context.Context) error {
 		}
 	}
 
-	// Attempt to parse SSH flags before triggering the goroutine, so we can exit
-	// if the parsing fails
+	if s.cfg.GoSSH {
+		level.Info(s.logger).Log("msg", "starting gossh client")
+		if len(s.cfg.SSHFlags) > 0 {
+			level.Warn(s.logger).Log("msg", "The -use-gossh flag ignores most -ssh-flag values.")
+			domains, err := MapSSHPermitToSocks(s.cfg.SSHFlags)
+			if err != nil {
+				return err
+			}
+			if len(domains) > 0 {
+				level.Warn(s.logger).Log("msg", "Please migrate PermitRemoteOpen domains to -permit-domains flag for the -use-gossh flag.")
+				s.cfg.PermitDomains = domains
+			}
+		}
+		go s.runGoSSH(ctx)
+		return nil
+	}
+
 	flags, err := s.SSHFlagsFromConfig()
 	if err != nil {
 		level.Error(s.logger).Log("msg", fmt.Sprintf("could not parse flags: %s", err))
@@ -252,11 +299,22 @@ func (s *Client) starting(ctx context.Context) error {
 			return err
 		})
 	}
-
 	return nil
 }
 
 func (s *Client) stopping(err error) error {
+	if s.sshClient != nil && s.forwardPort != nil {
+		_, _, e := s.sshClient.SendRequest("cancel-tcpip-forward", false, ssh.Marshal(&remoteForwardRequest{BindAddr: "", BindPort: *s.forwardPort}))
+
+		if e != nil {
+			level.Error(s.logger).Log("error sending cancel-tcpip-forward", e)
+		}
+	}
+
+	if s.sshClient != nil {
+		_ = s.sshClient.Close()
+	}
+
 	level.Info(s.logger).Log("msg", "stopping ssh client")
 	return err
 }

--- a/pkg/ssh/ssh.go
+++ b/pkg/ssh/ssh.go
@@ -170,9 +170,7 @@ func (s *Client) Describe(ch chan<- *prometheus.Desc) {
 	s.metrics.goOpenChannelsCount.Describe(ch)
 }
 
-func (s *Client) starting(ctx context.Context) error {
-	level.Info(s.logger).Log("msg", "starting ssh client")
-
+func (s *Client) checkForConflictingSSHFlags() {
 	if !s.cfg.GoSSH && len(s.cfg.PermitDomains) > 0 {
 		level.Warn(s.logger).Log("msg", "-permit-domains must be used with -use-gossh.")
 	}
@@ -180,6 +178,28 @@ func (s *Client) starting(ctx context.Context) error {
 	if !s.cfg.GoSSH && s.cfg.ConnectionTimeout > time.Second*1 {
 		level.Warn(s.logger).Log("msg", "-connect-timeout must be used with -use-gossh.")
 	}
+
+}
+
+func (s *Client) startGoSSH(ctx context.Context) error {
+	level.Info(s.logger).Log("msg", "starting gossh client")
+
+	if err := s.validateGoSSH(); err != nil {
+		return err
+	}
+
+	go func() {
+		if err := s.runGoSSH(ctx); err != nil && ctx.Err() == nil {
+			level.Error(s.logger).Log("msg", "gossh exited unexpectedly", "err", err)
+		}
+	}()
+
+	return nil
+}
+
+func (s *Client) starting(ctx context.Context) error {
+	level.Info(s.logger).Log("msg", "starting ssh client")
+	s.checkForConflictingSSHFlags()
 
 	if !s.cfg.GoSSH && !s.cfg.SkipSSHValidation {
 		if err := validateSSHVersion(ctx, s.logger, s.SSHCmd); err != nil {
@@ -198,19 +218,7 @@ func (s *Client) starting(ctx context.Context) error {
 	}
 
 	if s.cfg.GoSSH {
-		level.Info(s.logger).Log("msg", "starting gossh client")
-
-		if err := s.validateGoSSH(); err != nil {
-			return err
-		}
-
-		go func() {
-			if err := s.runGoSSH(ctx); err != nil && ctx.Err() == nil {
-				level.Error(s.logger).Log("msg", "gossh exited unexpectedly", "err", err)
-			}
-		}()
-
-		return nil
+		return s.startGoSSH(ctx)
 	}
 
 	flags, err := s.SSHFlagsFromConfig()

--- a/pkg/ssh/ssh.go
+++ b/pkg/ssh/ssh.go
@@ -107,8 +107,8 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 
 	f.IntVar(&cfg.DevPort, "dev-ssh-port", 2244, "[DEVELOPMENT ONLY] The port to use for agent connections to the PDC SSH gateway")
 	f.BoolVar(&cfg.GoSSH, "use-gossh", false, "Use Go-based SSH. Defaults to OpenSSH.")
-	f.Func("permit-domains", "List of domains that are allowed to recieve queries (defaults to 'all')", cfg.buildDomains)
-	f.DurationVar(&cfg.ConnectionTimeout, "connect-timeout", 1*time.Second, "Specifies the timeout (in seconds) used when connecting. Simliar to ConnectTimeout in OpenSSH.")
+	f.Func("permit-domains", "List of domains that are allowed to receive queries (defaults to 'all')", cfg.buildDomains)
+	f.DurationVar(&cfg.ConnectionTimeout, "connect-timeout", 1*time.Second, "Specifies the timeout (in seconds) used when connecting. Similar to ConnectTimeout in OpenSSH.")
 }
 
 func (cfg Config) KeyFileDir() string {
@@ -181,10 +181,6 @@ func (s *Client) starting(ctx context.Context) error {
 		level.Warn(s.logger).Log("msg", "-connect-timeout must be used with -use-gossh.")
 	}
 
-	if s.cfg.GoSSH && s.cfg.Connections > 1 {
-		level.Warn(s.logger).Log("msg", "-use-gossh doesn't respect the -connections flag currently")
-	}
-
 	if !s.cfg.GoSSH && !s.cfg.SkipSSHValidation {
 		if err := validateSSHVersion(ctx, s.logger, s.SSHCmd); err != nil {
 			return fmt.Errorf("invalid SSH version: %w", err)
@@ -203,18 +199,17 @@ func (s *Client) starting(ctx context.Context) error {
 
 	if s.cfg.GoSSH {
 		level.Info(s.logger).Log("msg", "starting gossh client")
-		if len(s.cfg.SSHFlags) > 0 {
-			level.Warn(s.logger).Log("msg", "The -use-gossh flag ignores most -ssh-flag values.")
-			domains, err := MapSSHPermitToSocks(s.cfg.SSHFlags)
-			if err != nil {
-				return err
-			}
-			if len(domains) > 0 {
-				level.Warn(s.logger).Log("msg", "Please migrate PermitRemoteOpen domains to -permit-domains flag for the -use-gossh flag.")
-				s.cfg.PermitDomains = domains
-			}
+
+		if err := s.validateGoSSH(); err != nil {
+			return err
 		}
-		go s.runGoSSH(ctx)
+
+		go func() {
+			if err := s.runGoSSH(ctx); err != nil && ctx.Err() == nil {
+				level.Error(s.logger).Log("msg", "gossh exited unexpectedly", "err", err)
+			}
+		}()
+
 		return nil
 	}
 

--- a/pkg/ssh/ssh_test.go
+++ b/pkg/ssh/ssh_test.go
@@ -477,6 +477,37 @@ func TestLoggerWriterAdapter(t *testing.T) {
 	}
 }
 
+func TestGoClientStarts(t *testing.T) {
+	logger := log.NewNopLogger()
+	cfg := ssh.DefaultConfig()
+	cfg.GoSSH = true
+	mClient := mockPDCClient{}
+	km := ssh.NewKeyManager(cfg, logger, mClient)
+	client := ssh.NewClient(cfg, logger, km)
+	client.SSHCmd = "foo/bar"
+
+	ctx := context.Background()
+
+	// When starting the client
+	err := client.StartAsync(ctx)
+	// Then the client should be in the starting state
+	assert.NoError(t, err)
+	assert.Equal(t, "Starting", client.State().String())
+
+	// And eventually move to the running state
+	err = client.AwaitRunning(ctx)
+	assert.NoError(t, err)
+	assert.Equal(t, "Running", client.State().String())
+
+	// When stopping the service
+	client.StopAsync()
+	assert.NoError(t, err)
+
+	// Then is should eventually move to the terminated state
+	_ = client.AwaitTerminated(ctx)
+	assert.Equal(t, "Terminated", client.State().String())
+}
+
 type assertLogger struct {
 	// iterate through assertFns, call one each time Write is called
 	assertFns []assertFn

--- a/pkg/ssh/sshgo.go
+++ b/pkg/ssh/sshgo.go
@@ -43,14 +43,6 @@ func (s *Client) validateGoSSH() error {
 			s.cfg.PermitDomains = domains
 		}
 	}
-	if _, err := deriveCertSigner(s.cfg.KeyFile, s.logger); err != nil {
-		return err
-	}
-
-	hostsfile := path.Join(s.cfg.KeyFileDir(), KnownHostsFile)
-	if _, err := knownhosts.New(hostsfile); err != nil {
-		return err
-	}
 
 	return nil
 }

--- a/pkg/ssh/sshgo.go
+++ b/pkg/ssh/sshgo.go
@@ -1,0 +1,243 @@
+package ssh
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"os"
+	"path"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+	"github.com/grafana/dskit/backoff"
+	"github.com/things-go/go-socks5"
+	"golang.org/x/crypto/ssh"
+	"golang.org/x/crypto/ssh/knownhosts"
+)
+
+type remoteForwardRequest struct {
+	BindAddr string
+	BindPort uint32
+}
+
+type remoteForwardResponse struct {
+	BindPort uint32
+}
+
+func (s *Client) runGoSSH(ctx context.Context) error {
+	backoffCtrl := backoff.New(ctx, backoff.Config{
+		MinBackoff: 1 * time.Second,
+		MaxBackoff: 16 * time.Second,
+		MaxRetries: 0, //persist until ctx is cancelled
+	})
+
+	for backoffCtrl.Ongoing() {
+		certSigner, err := deriveCertSigner(s.cfg.KeyFile, s.logger)
+
+		if err != nil {
+			level.Error(s.logger).Log("error making cert signer", err)
+			return err
+		}
+
+		keyFileArr := strings.Split(s.cfg.KeyFile, "/")
+		keyFileDir := strings.Join(keyFileArr[:len(keyFileArr)-1], "/")
+
+		hostsfile := path.Join(keyFileDir, KnownHostsFile)
+		hostCB, err := knownhosts.New(hostsfile)
+		if err != nil {
+			level.Error(s.logger).Log("error making knownhost", err)
+			return err
+		}
+
+		config := &ssh.ClientConfig{
+			User: s.cfg.PDC.HostedGrafanaID,
+			Auth: []ssh.AuthMethod{
+				ssh.PublicKeys(certSigner),
+			},
+			HostKeyCallback: hostCB,
+		}
+
+		host := net.JoinHostPort(s.cfg.URL.String(), strconv.Itoa(s.cfg.Port))
+		timerStart := time.Now()
+		var response remoteForwardResponse
+
+		conn, err := s.dialWithTimeout(ctx, host, config, timerStart)
+
+		if err != nil {
+			level.Error(s.logger).Log(err)
+			if conn != nil {
+				_ = conn.Close()
+			}
+			backoffCtrl.Wait()
+			continue
+		}
+
+		go doKeepAlives(ctx, s.sshClient.Conn, s.logger)
+
+		chans := s.sshClient.HandleChannelOpen("forwarded-tcpip")
+		s.metrics.timeToConnect.WithLabelValues("gossh").Observe(time.Since(timerStart).Seconds())
+
+		ln := NewListenerFromChannel(s.sshClient, chans, s.metrics)
+
+		server := socks5.NewServer(
+			socks5.WithDialAndRequest(s.socksDialerRequest),
+			socks5.WithRule(&PermitRemoteOpen{
+				Domains: s.cfg.PermitDomains,
+			}),
+		)
+
+		req := remoteForwardRequest{
+			BindAddr: "",
+			BindPort: 0,
+		}
+
+		ok, b, err := s.sshClient.SendRequest("tcpip-forward", true, ssh.Marshal(req))
+
+		if err != nil {
+			level.Error(s.logger).Log("error sending tcpip-forward", err)
+			s.waitAndClose(backoffCtrl)
+			continue
+		}
+
+		if !ok {
+			level.Error(s.logger).Log("tcpip-forward request rejected.")
+			s.waitAndClose(backoffCtrl)
+			continue
+		}
+
+		err = ssh.Unmarshal(b, &response)
+
+		if err != nil {
+			level.Error(s.logger).Log("error decoding response", err)
+			s.waitAndClose(backoffCtrl)
+			continue
+		}
+
+		backoffCtrl.Reset()
+
+		s.forwardPort = &response.BindPort //save for cancel later
+
+		err = server.Serve(ln)
+
+		//exit early if ctx is done
+		if ctx.Err() != nil {
+			return nil
+		}
+
+		if err != nil {
+			level.Error(s.logger).Log("error serving SOCKS", err)
+			s.waitAndClose(backoffCtrl)
+			continue
+		}
+
+		s.sshClient.Close()
+	}
+
+	return nil
+}
+
+func deriveCertSigner(keyFile string, logger log.Logger) (ssh.Signer, error) {
+	keyfile, err := os.ReadFile(keyFile)
+	if err != nil {
+		level.Error(logger).Log("error reading keyfile", err)
+		return nil, err
+	}
+
+	signer, err := ssh.ParsePrivateKey(keyfile)
+	if err != nil {
+		level.Error(logger).Log("error parsing keyfile", err)
+		return nil, err
+	}
+
+	certFile, err := os.ReadFile(fmt.Sprintf("%s-cert.pub", keyFile))
+	if err != nil {
+		level.Error(logger).Log("error reading cert", err)
+		return nil, err
+	}
+
+	authKey, _, _, _, err := ssh.ParseAuthorizedKey(certFile)
+	if err != nil {
+		level.Error(logger).Log("error parsing authKey", err)
+		return nil, err
+	}
+
+	cert, ok := authKey.(*ssh.Certificate)
+
+	if !ok {
+		return nil, fmt.Errorf("parsed authorized key is %T, want *ssh.Certificate", authKey)
+	}
+
+	return ssh.NewCertSigner(cert, signer)
+}
+
+// dialWithTimeout does what ssh.Dial does but wires in ConnectionTimeout since ssh.ClientConfig doesn't cover the ssh handshake.
+// dialWithTimeout is meant to mimic ConnectTimeout from ssh_config.
+func (s *Client) dialWithTimeout(ctx context.Context, host string, config *ssh.ClientConfig, timerStart time.Time) (net.Conn, error) {
+	d := net.Dialer{Timeout: s.cfg.ConnectionTimeout, KeepAlive: -1}
+	conn, err := d.DialContext(ctx, "tcp", host)
+	if err != nil {
+		return nil, fmt.Errorf("error dialing context: %w", err)
+	}
+
+	err = conn.SetDeadline(timerStart.Add(s.cfg.ConnectionTimeout))
+
+	if err != nil {
+		return conn, fmt.Errorf("error setting deadline: %w", err)
+	}
+
+	c, chans, reqs, err := ssh.NewClientConn(conn, host, config)
+	if err != nil {
+		return conn, fmt.Errorf("error getting client conn: %w", err)
+	}
+
+	err = conn.SetDeadline(time.Time{})
+	if err != nil {
+		return conn, fmt.Errorf("error clearing deadline: %w", err)
+	}
+
+	s.sshClient = ssh.NewClient(c, chans, reqs)
+
+	return conn, nil
+}
+
+func (s *Client) waitAndClose(backoffCtrl *backoff.Backoff) {
+	err := "gossh error"
+
+	if backoffCtrl.ErrCause() != nil {
+		err = backoffCtrl.ErrCause().Error()
+	}
+
+	s.metrics.sshRestartsCount.WithLabelValues("gossh", err).Inc()
+	backoffCtrl.Wait()
+	s.sshClient.Close()
+}
+
+// socksDialerRequest is needed to fill the tcp_connections_total target label like OpenSSH does.
+func (s *Client) socksDialerRequest(ctx context.Context, network string, addr string, req *socks5.Request) (net.Conn, error) {
+	var d net.Dialer
+	port := "0"
+	domainAndPort := ""
+
+	if req.RawDestAddr.Port >= 0 {
+		port = strconv.Itoa(req.RawDestAddr.Port)
+	}
+
+	if req.RawDestAddr.FQDN != "" {
+		domainAndPort = net.JoinHostPort(req.RawDestAddr.FQDN, port)
+	} else {
+		domainAndPort = net.JoinHostPort(req.RawDestAddr.IP.String(), port)
+	}
+
+	conn, err := d.DialContext(ctx, network, addr)
+
+	if err != nil {
+		s.metrics.tcpConnectionsCount.WithLabelValues("1", domainAndPort, "failure").Add(1)
+		return nil, err
+	}
+	s.metrics.tcpConnectionsCount.WithLabelValues("1", domainAndPort, "success").Add(1)
+
+	return conn, nil
+}

--- a/pkg/ssh/sshgo.go
+++ b/pkg/ssh/sshgo.go
@@ -27,6 +27,34 @@ type remoteForwardResponse struct {
 	BindPort uint32
 }
 
+func (s *Client) validateGoSSH() error {
+	if s.cfg.Connections > 1 {
+		level.Warn(s.logger).Log("msg", "-use-gossh doesn't respect the -connections flag currently")
+	}
+
+	if len(s.cfg.SSHFlags) > 0 {
+		level.Warn(s.logger).Log("msg", "The -use-gossh flag ignores most -ssh-flag values.")
+		domains, err := MapSSHPermitToSocks(s.cfg.SSHFlags)
+		if err != nil {
+			return err
+		}
+		if len(domains) > 0 {
+			level.Warn(s.logger).Log("msg", "Please migrate PermitRemoteOpen domains to -permit-domains flag for the -use-gossh flag.")
+			s.cfg.PermitDomains = domains
+		}
+	}
+	if _, err := deriveCertSigner(s.cfg.KeyFile, s.logger); err != nil {
+		return err
+	}
+
+	hostsfile := path.Join(s.cfg.KeyFileDir(), KnownHostsFile)
+	if _, err := knownhosts.New(hostsfile); err != nil {
+		return err
+	}
+
+	return nil
+}
+
 func (s *Client) runGoSSH(ctx context.Context) error {
 	backoffCtrl := backoff.New(ctx, backoff.Config{
 		MinBackoff: 1 * time.Second,
@@ -67,7 +95,7 @@ func (s *Client) runGoSSH(ctx context.Context) error {
 		conn, err := s.dialWithTimeout(ctx, host, config, timerStart)
 
 		if err != nil {
-			level.Error(s.logger).Log(err)
+			level.Error(s.logger).Log("error during dialWithTimeout", err)
 			if conn != nil {
 				_ = conn.Close()
 			}
@@ -103,7 +131,7 @@ func (s *Client) runGoSSH(ctx context.Context) error {
 		}
 
 		if !ok {
-			level.Error(s.logger).Log("tcpip-forward request rejected.")
+			level.Error(s.logger).Log("tcpip-forward request rejected.", ok)
 			s.waitAndClose(backoffCtrl)
 			continue
 		}


### PR DESCRIPTION
"Shelling out" to `ssh` has two big limitations:

1. `ssh` is single-threaded.
2. We don't get "native" metrics, we have to derive them from logs.

Connections were an attempt to paper over the fact that `ssh` was single-threaded. To that end, I haven't ported over connections to the Go ssh approach. In this approach, we run a retry loop around a single SSH connection where multiple channels can be handled via go routines.

No connections also means to shut down the agent we only need to send `cancel` to the server and then close the client. This should enable better close semantics on the server as well.

## Testing

append `-use-gossh` to any pdc-agent command line call.