### PR TITLE
chore: bump Go to 1.25.9

### DIFF
--- a/.github/workflows/go_build.yml
+++ b/.github/workflows/go_build.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6
         with:
-          go-version: "1.25.8"
+          go-version: "1.25.9"
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false

--- a/.github/workflows/go_lint.yml
+++ b/.github/workflows/go_lint.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
       - uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6
         with:
-          go-version: "1.25.8"
+          go-version: "1.25.9"
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
       - run: git fetch --force --tags
       - uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6
         with:
-          go-version: "1.25.8"
+          go-version: "1.25.9"
           cache: false
       # setup docker buildx
       - name: Set up QEMU

--- a/.github/workflows/testing-release.yml
+++ b/.github/workflows/testing-release.yml
@@ -22,7 +22,7 @@ jobs:
       - run: git fetch --force --tags
       - uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6
         with:
-          go-version: "1.25.8"
+          go-version: "1.25.9"
           cache: false
       - name: Login to DockerHub
         uses: grafana/shared-workflows/actions/dockerhub-login@081a366728379fd0426b9cfef190e9a21c2d5418 # dockerhub-login/v1.0.3

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/pdc-agent
 
-go 1.25.8
+go 1.25.9
 
 require (
 	github.com/go-kit/log v0.2.1


### PR DESCRIPTION
## Summary
- Bump Go from 1.25.8 to 1.25.9 across `go.mod` and all CI workflows
- The next release build will also pick up the latest Alpine packages (OpenSSL 3.5.6-r0, musl 1.2.5-r23) via the existing `apk upgrade` in the Dockerfile

## Test plan
- [ ] CI build and lint workflows pass with Go 1.25.9
- [ ] Tests pass


🤖 Generated with [Claude Code](https://claude.com/claude-code)