### PR TITLE
Harden github workflows

### DIFF
--- a/.github/.zizmor.yml
+++ b/.github/.zizmor.yml
@@ -1,9 +1,13 @@
 # This is also used as the default configuration for the Zizmor reusable
 # workflow.
+#
+# Every `uses:` in this repo is pinned to a commit SHA, so we require hash-pin
+# universally. If a future change needs to land an action that genuinely can't
+# be SHA-pinned, narrow the exception to that specific action rather than
+# loosening the org-wide policy.
 
 rules:
   unpinned-uses:
     config:
       policies:
-        actions/*: any # trust GitHub
-        grafana/*: any # trust Grafana
+        "*": hash-pin

--- a/.github/workflows/go_lint.yml
+++ b/.github/workflows/go_lint.yml
@@ -26,5 +26,5 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
         with:
-          version: latest
+          version: v2.12.2
           args: --max-same-issues=0 --max-issues-per-linter=0

--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -12,6 +12,8 @@ permissions:
 
 jobs:
   snyk-scan-ci:
-    uses: 'grafana/security-github-actions/.github/workflows/snyk_monitor.yml@main'
+    # Pinned to a commit SHA on main; this repo has no tagged releases. Bump
+    # when dependabot opens a PR or when a meaningful change lands upstream.
+    uses: 'grafana/security-github-actions/.github/workflows/snyk_monitor.yml@5140d598f06d98b6f62bdae3ff66ea31f2994300' # main @ 2026-05-22
     secrets:
       SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}


### PR DESCRIPTION
Part of a general security hardening effort: 

Changes: 
- zizmor: iiuc this change will force hashpins on all actions
- go-lint: specifically use a particular version when linting in github actions (annoyingly will require manual updates but if the golangci lint project was ever compromised this should help us out
- snyk: pin snyk action