### PR TITLE
ci: publish images to GAR

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,8 +32,10 @@ jobs:
         uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
-      - name: Login to DockerHub
-        uses: grafana/shared-workflows/actions/dockerhub-login@081a366728379fd0426b9cfef190e9a21c2d5418 # dockerhub-login/v1.0.3
+      - name: Login to GAR
+        uses: grafana/shared-workflows/actions/login-to-gar@c7ad5f57693ac858c698d95783685a9cbfd91223 # login-to-gar/v1.0.1
+        with:
+          registry: us-docker.pkg.dev
       - uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6.4.0
         with:
           distribution: goreleaser

--- a/.github/workflows/testing-release.yml
+++ b/.github/workflows/testing-release.yml
@@ -24,12 +24,14 @@ jobs:
         with:
           go-version: "1.26.4"
           cache: false
-      - name: Login to DockerHub
-        uses: grafana/shared-workflows/actions/dockerhub-login@081a366728379fd0426b9cfef190e9a21c2d5418 # dockerhub-login/v1.0.3
+      - name: Login to GAR
+        uses: grafana/shared-workflows/actions/login-to-gar@c7ad5f57693ac858c698d95783685a9cbfd91223 # login-to-gar/v1.0.1
+        with:
+          registry: us-docker.pkg.dev
       - name: Build and push snapshot Docker image
         run: |
           TAG="$(git rev-parse --short HEAD)"
-          NAME="grafana/pdc-agent:testing-${TAG}"
+          NAME="us-docker.pkg.dev/grafanalabs-global/dockerhub-pdc-agent-prod-mirror/pdc-agent:testing-${TAG}"
           CGO_ENABLED=0 make build
           cp pdc cmd/pdc/pdc
           docker build -t "${NAME}" cmd/pdc/

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -45,10 +45,10 @@ dockers:
       - pdc
     dockerfile: ./cmd/pdc/Dockerfile
     image_templates:
-      - grafana/{{ .ProjectName }}:latest
-      - grafana/{{ .ProjectName }}:latest-amd64
-      - grafana/{{ .ProjectName }}:{{ .Version }}
-      - grafana/{{ .ProjectName }}:{{ .Version }}-amd64
+      - us-docker.pkg.dev/grafanalabs-global/dockerhub-pdc-agent-prod-mirror/{{ .ProjectName }}:latest
+      - us-docker.pkg.dev/grafanalabs-global/dockerhub-pdc-agent-prod-mirror/{{ .ProjectName }}:latest-amd64
+      - us-docker.pkg.dev/grafanalabs-global/dockerhub-pdc-agent-prod-mirror/{{ .ProjectName }}:{{ .Version }}
+      - us-docker.pkg.dev/grafanalabs-global/dockerhub-pdc-agent-prod-mirror/{{ .ProjectName }}:{{ .Version }}-amd64
     build_flag_templates:
       - "--platform=linux/amd64"
       - "--provenance=false"
@@ -59,21 +59,21 @@ dockers:
       - pdc
     dockerfile: ./cmd/pdc/Dockerfile
     image_templates:
-      - grafana/{{ .ProjectName }}:latest-arm64
-      - grafana/{{ .ProjectName }}:{{ .Version }}-arm64
+      - us-docker.pkg.dev/grafanalabs-global/dockerhub-pdc-agent-prod-mirror/{{ .ProjectName }}:latest-arm64
+      - us-docker.pkg.dev/grafanalabs-global/dockerhub-pdc-agent-prod-mirror/{{ .ProjectName }}:{{ .Version }}-arm64
     build_flag_templates:
       - "--platform=linux/arm64"
       - "--provenance=false"
 
 docker_manifests:
-- name_template: 'grafana/{{ .ProjectName }}:{{ .Version }}'
+- name_template: 'us-docker.pkg.dev/grafanalabs-global/dockerhub-pdc-agent-prod-mirror/{{ .ProjectName }}:{{ .Version }}'
   image_templates:
-  - 'grafana/{{ .ProjectName }}:{{ .Version }}-amd64'
-  - 'grafana/{{ .ProjectName }}:{{ .Version }}-arm64'
-- name_template: 'grafana/{{ .ProjectName }}:latest'
+  - 'us-docker.pkg.dev/grafanalabs-global/dockerhub-pdc-agent-prod-mirror/{{ .ProjectName }}:{{ .Version }}-amd64'
+  - 'us-docker.pkg.dev/grafanalabs-global/dockerhub-pdc-agent-prod-mirror/{{ .ProjectName }}:{{ .Version }}-arm64'
+- name_template: 'us-docker.pkg.dev/grafanalabs-global/dockerhub-pdc-agent-prod-mirror/{{ .ProjectName }}:latest'
   image_templates:
-  - 'grafana/{{ .ProjectName }}:latest-amd64'
-  - 'grafana/{{ .ProjectName }}:latest-arm64'
+  - 'us-docker.pkg.dev/grafanalabs-global/dockerhub-pdc-agent-prod-mirror/{{ .ProjectName }}:latest-amd64'
+  - 'us-docker.pkg.dev/grafanalabs-global/dockerhub-pdc-agent-prod-mirror/{{ .ProjectName }}:latest-arm64'
 
 
 


### PR DESCRIPTION
push images to GAR rather than to dockerhub directly, we then have a separate service which will publish on dockerhub