### PR TITLE
fix: parse Windows OpenSSH version output

### DIFF
--- a/pkg/ssh/ssh.go
+++ b/pkg/ssh/ssh.go
@@ -462,7 +462,7 @@ func (adapter LoggerWriterAdapter) Write(p []byte) (n int, err error) {
 }
 
 // openssh must be running 9.2 or above
-// checks version in format OpenSSH_{MAJOR}.{MINOR}
+// checks version in OpenSSH_{MAJOR}.{MINOR} or OpenSSH_for_Windows_{MAJOR}.{MINOR} format
 func validateSSHVersion(ctx context.Context, logger log.Logger, sshCmd string) error {
 	out, err := exec.CommandContext(ctx, sshCmd, "-V").CombinedOutput()
 	if err != nil {
@@ -479,7 +479,7 @@ func validateSSHVersion(ctx context.Context, logger log.Logger, sshCmd string) e
 	return RequireSSHVersionAbove9_2(major, minor)
 }
 
-var sshVersionRegexp = regexp.MustCompile(`OpenSSH_(\d+)\.(\d+)`)
+var sshVersionRegexp = regexp.MustCompile(`OpenSSH(?:_for_Windows)?_(\d+)\.(\d+)`)
 
 func ParseSSHVersion(version string) (int, int, error) {
 	matches := sshVersionRegexp.FindStringSubmatch(version)

--- a/pkg/ssh/ssh_test.go
+++ b/pkg/ssh/ssh_test.go
@@ -398,6 +398,14 @@ func TestSSHVersionValidation(t *testing.T) {
 			version: "OpenSSH_19.1p1, test ssh metadata",
 			valid:   true,
 		},
+		{
+			version: "OpenSSH_for_Windows_7.7p1",
+			valid:   false,
+		},
+		{
+			version: "OpenSSH_for_Windows_9.5p1, LibreSSL 3.8.2",
+			valid:   true,
+		},
 	}
 	for _, tc := range testcases {
 		t.Run(tc.version, func(t *testing.T) {
@@ -414,6 +422,26 @@ func TestSSHVersionValidation(t *testing.T) {
 		})
 	}
 
+}
+
+func TestParseWindowsSSHVersion(t *testing.T) {
+	testcases := []struct {
+		version string
+		major   int
+		minor   int
+	}{
+		{version: "OpenSSH_for_Windows_7.7p1", major: 7, minor: 7},
+		{version: "OpenSSH_for_Windows_9.5p1, LibreSSL 3.8.2", major: 9, minor: 5},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.version, func(t *testing.T) {
+			major, minor, err := ssh.ParseSSHVersion(tc.version)
+			require.NoError(t, err)
+			require.Equal(t, tc.major, major)
+			require.Equal(t, tc.minor, minor)
+		})
+	}
 }
 
 type assertFn func(t *testing.T, s string)


### PR DESCRIPTION
## Summary

- accept the `OpenSSH_for_Windows_<major>.<minor>` prefix in SSH version parsing
- preserve support for the existing Unix/macOS `OpenSSH_<major>.<minor>` format
- add Windows 7.7 and 9.5 parsing/validation cases using the output forms reported in the issue

Closes #106.

## Validation

### Regression test

Before the regex change, all new Windows parsing cases failed with `failed to parse OpenSSH version`. The same focused tests pass after the change.

### Test suite

- `go test ./... -count=1` — all packages passed
- `go test -race ./pkg/ssh -count=1` — passed
- `go vet ./pkg/ssh` — passed
- `gofmt -d pkg/ssh/ssh.go pkg/ssh/ssh_test.go` — clean
- `git diff --check`

Validation used the repository-pinned Go 1.26.4 toolchain from the official go.dev distribution.